### PR TITLE
fix: tree.png not showing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ graph = tree_to_dot(root, node_colour="gold")
 graph.write_png("assets/tree.png")
 ```
 
-![Sample Tree Output](../../assets/tree.png)
+![Sample Tree Output](https://github.com/kayjan/bigtree/raw/master/assets/tree.png)
 
 ```python
 from bigtree import Node, print_tree


### PR DESCRIPTION
Also broken on pypi

![bigtree_pypi](https://user-images.githubusercontent.com/22630684/201390980-d0efe549-e63b-466a-9079-3ccfddb35791.png)

Replaced by absolute link. 
