### PR TITLE
Updates dataframe_to_tree to work with path_col param

### DIFF
--- a/bigtree/tree/construct.py
+++ b/bigtree/tree/construct.py
@@ -793,6 +793,8 @@ def dataframe_to_tree(
     add_dataframe_to_tree_by_path(
         root_node,
         data,
+        path_col=path_col,
+        attribute_cols=attribute_cols,
         sep=sep,
         duplicate_name_allowed=duplicate_name_allowed,
     )

--- a/tests/tree/test_construct.py
+++ b/tests/tree/test_construct.py
@@ -1397,6 +1397,26 @@ class TestDataFrameToTree(unittest.TestCase):
         assert_tree_structure_node_root_generic(root)
 
     @staticmethod
+    def test_dataframe_to_tree_col_name_not_first():
+        path_data = pd.DataFrame(
+            [
+                [90, "a"],
+                [65, "a/b"],
+                [60, "a/c"],
+                [40, "a/b/d"],
+                [35, "a/b/e"],
+                [38, "a/c/f"],
+                [10, "a/b/e/g"],
+                [6, "a/b/e/h"],
+            ],
+            columns=["age", "PATH"],
+        )
+        root = dataframe_to_tree(path_data, path_col="PATH")
+        assert_tree_structure_basenode_root_generic(root)
+        assert_tree_structure_basenode_root_attr(root)
+        assert_tree_structure_node_root_generic(root)
+
+    @staticmethod
     def test_dataframe_to_tree_no_attribute():
         path_data = pd.DataFrame(
             [


### PR DESCRIPTION
Adds path_col and attribute_cols params to the add_dataframe_to_tree_by_path function call so that they work as advertised in the dataframe_to_tree function. Updates test to reflect changes

Fixes issue #58