### PR TITLE
Add alias to print_tree option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added:
+- Tree Export: Print tree to allow alias.
 - Tree Export: Mermaid diagram to include theme.
 ### Fixed:
 - Misc: Doctest for docstrings, docstring to indicate usage prefers `node_name` to `name`.

--- a/bigtree/tree/export.py
+++ b/bigtree/tree/export.py
@@ -55,6 +55,7 @@ T = TypeVar("T", bound=node.Node)
 
 def print_tree(
     tree: T,
+    alias: str = "node_name",
     node_name_or_path: str = "",
     max_depth: int = 0,
     all_attrs: bool = False,
@@ -195,6 +196,8 @@ def print_tree(
 
     Args:
         tree (Node): tree to print
+        alias (Optional[str]): node attribute to use for node name in tree as alias to `node_name`, if present.
+            Otherwise, it will default to `node_name` of node.
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         all_attrs (bool): indicator to show all attributes, defaults to False, overrides `attr_list` and `attr_omit_null`
@@ -236,7 +239,8 @@ def print_tree(
             attr_str = ", ".join(attr_str_list)
             if attr_str:
                 attr_str = f" {attr_bracket_open}{attr_str}{attr_bracket_close}"
-        node_str = f"{_node.node_name}{attr_str}"
+        name_str = _node.get_attr(alias) or _node.node_name
+        node_str = f"{name_str}{attr_str}"
         print(f"{pre_str}{fill_str}{node_str}", **kwargs)
 
 

--- a/bigtree/tree/export.py
+++ b/bigtree/tree/export.py
@@ -68,6 +68,7 @@ def print_tree(
     """Print tree to console, starting from `tree`.
     Accepts kwargs for print() function.
 
+    - Able to have alias for node name if alias attribute is present, else it falls back to node_name, using `alias`
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
     - Able to customize for maximum depth to print, using `max_depth`
     - Able to choose which attributes to show or show all attributes, using `attr_name_filter` and `all_attrs`
@@ -1592,6 +1593,7 @@ def tree_to_mermaid(
     Args:
         tree (Node): tree to be exported
         title (str): title, defaults to None
+        theme (str): theme or colour scheme, defaults to None
         rankdir (str): layout direction, defaults to 'TB' (top to bottom), can be 'BT' (bottom to top),
             'LR' (left to right), 'RL' (right to left)
         line_shape (str): line shape or curvature, defaults to 'basis'

--- a/bigtree/tree/export.py
+++ b/bigtree/tree/export.py
@@ -86,9 +86,9 @@ def print_tree(
         **Printing tree**
 
         >>> from bigtree import Node, print_tree
-        >>> root = Node("a", age=90)
+        >>> root = Node("a", alias="alias-a", age=90)
         >>> b = Node("b", age=65, parent=root)
-        >>> c = Node("c", age=60, parent=root)
+        >>> c = Node("c", alias="alias-c", age=60, parent=root)
         >>> d = Node("d", age=40, parent=b)
         >>> e = Node("e", age=35, parent=b)
         >>> print_tree(root)
@@ -97,6 +97,15 @@ def print_tree(
         │   ├── d
         │   └── e
         └── c
+
+        **Printing alias**
+
+        >>> print_tree(root, alias="alias")
+        alias-a
+        ├── b
+        │   ├── d
+        │   └── e
+        └── alias-c
 
         **Printing Sub-tree**
 

--- a/docs/gettingstarted/demo/tree.md
+++ b/docs/gettingstarted/demo/tree.md
@@ -333,9 +333,9 @@ Alternatively, the `print_tree` or `hprint_tree` method can be used.
 ```python hl_lines="8 15"
 from bigtree import Node, print_tree, hprint_tree
 
-root = Node("a", age=90, gender="F")
+root = Node("a", alias="alias-a", age=90, gender="F")
 b = Node("b", age=65, gender="M", parent=root)
-c = Node("c", age=60, gender="M", parent=root)
+c = Node("c", alias="alias-c", age=60, gender="M", parent=root)
 d = Node("d", age=40, gender="F", parent=b)
 e = Node("e", age=35, gender="M", parent=b)
 print_tree(root) # (1)!
@@ -357,10 +357,20 @@ hprint_tree(root) # (2)!
 
 Other customizations for printing are also available, such as:
 
+- Printing alias instead of node name, if present
 - Printing subtree
 - Printing tree with attributes
 - Different built-in or custom style
 
+=== "Alias"
+    ```python hl_lines="1"
+    root.show(alias="alias")
+    # alias-a
+    # ├── b
+    # │   ├── d
+    # │   └── e
+    # └── alias-c
+    ```
 === "Subtree"
     ```python hl_lines="1 6"
     root.show(node_name_or_path="b")

--- a/tests/tree/test_export.py
+++ b/tests/tree/test_export.py
@@ -55,6 +55,34 @@ LOCAL = Constants.LOCAL
 
 class TestPrintTree:
     @staticmethod
+    def test_print_tree(tree_node):
+        assert_print_statement(
+            export.print_tree,
+            tree_node_no_attr_str,
+            tree=tree_node,
+        )
+
+    @staticmethod
+    def test_print_tree_alias(tree_node):
+        expected_str = (
+            "alias a\n"
+            "├── b\n"
+            "│   ├── d\n"
+            "│   └── e\n"
+            "│       ├── g\n"
+            "│       └── h\n"
+            "└── c\n"
+            "    └── f\n"
+        )
+        tree_node.set_attrs({"alias": "alias a"})
+        assert_print_statement(
+            export.print_tree,
+            expected_str,
+            tree=tree_node,
+            alias="alias",
+        )
+
+    @staticmethod
     def test_print_tree_child_node_name(tree_node):
         # fmt: off
         expected_str = (


### PR DESCRIPTION
## Description
If alias node attribute is present, alias name will appear instead of `node_name`, otherwise `node_name` will be used

## Testing
<!-- Describe the tests added (tests for new feature, tests for bugfix) -->

## Additional notes
<!-- Any information that might be useful for review -->

## Checklist
I have read through the [contributing guidelines](https://bigtree.readthedocs.io/en/stable/home/contributing/) and ensured that
- [x] I have added a descriptive title for this pull request.
- [x] I have followed the convention and standards, and my code is checked for style and correctness.
- [x] I have added test cases, and unit tests pass with 100% code coverage.
- [x] I have updated the documentation and code docstrings.

## Checklist (for reviewer)
- [x] I have added label (breaking / enhancement / bug / documentation) to this pull request, if applicable.
- [x] I will ensure this change is captured in the *CHANGELOG.md* file.
