### PR TITLE
Fix get_tree_diff if path are substring of a modified path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 - Misc: Doctest for docstrings, docstring to indicate usage prefers `node_name` to `name`.
 - Tree Export: Mermaid diagram title to add newline.
+- Tree Helper: Get tree diff string replacement bug when the path change is substring of another path.
 
 ## [0.22.1] - 2024-11-03
 ### Added:
@@ -21,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0] - 2024-11-03
 ### Added:
-- Tree Helper: Accept parameter `detail` to show the different types of shift e.g., moved / added / removed. By default it is false.
+- Tree Helper: Accept parameter `detail` to show the different types of shift e.g., moved / added / removed. By default
+it is false.
 
 ## [0.21.3] - 2024-10-16
 ### Added:
@@ -96,10 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.0] - 2024-06-15
 ### Changed:
-- Tree Exporter: Print functions to accept custom style that is implemented as dataclass, this is a more
-object-oriented way of parsing arguments.
-This affects functions `print_tree`, `yield_tree`, `hprint_tree`, and `hyield_tree`.
-The argument `custom_style` is deprecated, and argument `style` is used instead.
+- Tree Exporter: Print functions to accept custom style that is implemented as dataclass, this is a more  object-oriented
+way of parsing arguments. This affects functions `print_tree`, `yield_tree`, `hprint_tree`, and `hyield_tree`. The
+argument `custom_style` is deprecated, and argument `style` is used instead.
 **This might not be backwards-compatible!**
 - Misc: Update docstrings to be more comprehensive for tree constructor and tree exporter.
 - Misc: Update documentation badges and conda information.

--- a/tests/tree/test_helper.py
+++ b/tests/tree/test_helper.py
@@ -242,7 +242,14 @@ class TestTreeDiff:
         )
         other_tree_node = node.Node("a", children=[node.Node("b")])
         tree_only_diff = helper.get_tree_diff(tree_node, other_tree_node)
-        expected_str = "a\n" "├── b (+)\n" "└── bb (-)\n" "    └── b (-)"
+        # fmt: off
+        expected_str = (
+            "a\n"
+            "├── b (+)\n"
+            "└── bb (-)\n"
+            "    └── b (-)\n"
+        )
+        # fmt: on
         assert_print_statement(export.print_tree, expected_str, tree=tree_only_diff)
 
     @staticmethod

--- a/tests/tree/test_helper.py
+++ b/tests/tree/test_helper.py
@@ -236,6 +236,16 @@ class TestTreeDiff:
         assert_print_statement(export.print_tree, expected_str, tree=tree_only_diff)
 
     @staticmethod
+    def test_tree_diff_same_prefix():
+        tree_node = node.Node(
+            "a", children=[node.Node("bb", children=[node.Node("b")])]
+        )
+        other_tree_node = node.Node("a", children=[node.Node("b")])
+        tree_only_diff = helper.get_tree_diff(tree_node, other_tree_node)
+        expected_str = "a\n" "├── b (+)\n" "└── bb (-)\n" "    └── b (-)"
+        assert_print_statement(export.print_tree, expected_str, tree=tree_only_diff)
+
+    @staticmethod
     def test_tree_diff_diff_sep_error(tree_node):
         other_tree_node = helper.prune_tree(tree_node, "a/c")
         other_tree_node.sep = "-"


### PR DESCRIPTION
## Description
When suffix is being added to path, it might have been substring of another path. This is the fix for the bug.

## Testing
<!-- Describe the tests added (tests for new feature, tests for bugfix) -->

## Additional notes
<!-- Any information that might be useful for review -->

## Checklist
I have read through the [contributing guidelines](https://bigtree.readthedocs.io/en/stable/home/contributing/) and ensured that
- [x] I have added a descriptive title for this pull request.
- [x] I have followed the convention and standards, and my code is checked for style and correctness.
- [x] I have added test cases, and unit tests pass with 100% code coverage.
- [x] I have updated the documentation and code docstrings.

## Checklist (for reviewer)
- [x] I have added label (breaking / enhancement / bug / documentation) to this pull request, if applicable.
- [x] I will ensure this change is captured in the *CHANGELOG.md* file.
