### PR TITLE
Make Node name mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Tree Search: Search relative path allows unix folder expression for leading sep symbol.
+- Node: Updated Node signature to reflect that name is mandatory.
 
 ## [0.23.0] - 2024-12-26
 ### Changed:

--- a/bigtree/node/node.py
+++ b/bigtree/node/node.py
@@ -79,7 +79,7 @@ class Node(basenode.BaseNode):
 
     """
 
-    def __init__(self, name: str = "", sep: str = "/", **kwargs: Any):
+    def __init__(self, name: str, sep: str = "/", **kwargs: Any):
         self.name = name
         self._sep = sep
         super().__init__(**kwargs)

--- a/tests/node/test_node.py
+++ b/tests/node/test_node.py
@@ -48,7 +48,7 @@ class TestNode(unittest.TestCase):
 
     def test_empty_node_name_error(self):
         with pytest.raises(exceptions.TreeError) as exc_info:
-            node.Node()
+            node.Node("")
         assert str(exc_info.value) == Constants.ERROR_NODE_NAME
 
     def test_set_parent(self):


### PR DESCRIPTION
## Description
Node name is already mandatory, but function signature causes confusion. Fixing this

## Testing
<!-- Describe the tests added (tests for new feature, tests for bugfix) -->

## Additional notes
<!-- Any information that might be useful for review -->

## Checklist
I have read through the [contributing guidelines](https://bigtree.readthedocs.io/en/stable/home/contributing/) and ensured that
- [x] I have added a descriptive title for this pull request.
- [x] I have followed the convention and standards, and my code is checked for style and correctness.
- [x] I have added test cases, and unit tests pass with 100% code coverage.
- [x] I have updated the documentation and code docstrings.

## Checklist (for reviewer)
- [x] I have added label (breaking / enhancement / bug / documentation) to this pull request, if applicable.
- [x] I will ensure this change is captured in the *CHANGELOG.md* file.
