### PR TITLE
Hprint to support multiline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Tree Exporter: `vprint_tree` to have same arguments as `vyield_tree`, add more test cases.
+- Tree Exporter: `hprint_tree` to support multiline node name, alias, and border style.
 
 ## [0.25.0] - 2025-02-25
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.25.0] - 2025-02-25
+## [0.25.1] - 2025-02-28
 ### Added:
 - Tree Exporter: `vprint_tree` to have same arguments as `vyield_tree`, add more test cases.
 - Tree Exporter: `hprint_tree` to support multiline node name, alias, and border style.
@@ -741,7 +741,8 @@ ignore null attribute columns.
 - Utility Iterator: Tree traversal methods.
 - Workflow To Do App: Tree use case with to-do list implementation.
 
-[Unreleased]: https://github.com/kayjan/bigtree/compare/0.25.0...HEAD
+[Unreleased]: https://github.com/kayjan/bigtree/compare/0.25.1...HEAD
+[0.25.1]: https://github.com/kayjan/bigtree/compare/0.25.0...0.25.1
 [0.25.0]: https://github.com/kayjan/bigtree/compare/0.24.0...0.25.0
 [0.24.0]: https://github.com/kayjan/bigtree/compare/0.23.1...0.24.0
 [0.23.1]: https://github.com/kayjan/bigtree/compare/0.23.0...0.23.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.25.0] - 2025-02-25
 ### Added:
 - Tree Exporter: `tree_to_pillow_graph` method to allow cmap for node background and generic kwargs for yield_tree.
 - Tree Exporter: `vprint_tree` method to print trees vertically, able to use `.vshow()` as well.
@@ -734,7 +736,8 @@ ignore null attribute columns.
 - Utility Iterator: Tree traversal methods.
 - Workflow To Do App: Tree use case with to-do list implementation.
 
-[Unreleased]: https://github.com/kayjan/bigtree/compare/0.24.0...HEAD
+[Unreleased]: https://github.com/kayjan/bigtree/compare/0.25.0...HEAD
+[0.25.0]: https://github.com/kayjan/bigtree/compare/0.24.0...0.25.0
 [0.24.0]: https://github.com/kayjan/bigtree/compare/0.23.1...0.24.0
 [0.23.1]: https://github.com/kayjan/bigtree/compare/0.23.0...0.23.1
 [0.23.0]: https://github.com/kayjan/bigtree/compare/0.22.3...0.23.0

--- a/bigtree/__init__.py
+++ b/bigtree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.25.0"
+__version__ = "0.25.1"
 
 from bigtree.binarytree.construct import list_to_binarytree
 from bigtree.dag.construct import dataframe_to_dag, dict_to_dag, list_to_dag

--- a/bigtree/__init__.py
+++ b/bigtree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.24.0"
+__version__ = "0.25.0"
 
 from bigtree.binarytree.construct import list_to_binarytree
 from bigtree.dag.construct import dataframe_to_dag, dict_to_dag, list_to_dag

--- a/bigtree/tree/export/_stdout.py
+++ b/bigtree/tree/export/_stdout.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from typing import List, Optional, TypeVar
+from typing import List, Optional, TypeVar, Union
 
 from bigtree.node import node
-from bigtree.utils.constants import BaseVPrintStyle, BorderStyle
+from bigtree.utils.constants import BaseHPrintStyle, BaseVPrintStyle, BorderStyle
 
 __all__ = [
     "calculate_stem_pos",
     "format_node",
     "horizontal_join",
+    "vertical_join",
 ]
 
 T = TypeVar("T", bound=node.Node)
@@ -30,20 +31,26 @@ def calculate_stem_pos(length: int) -> int:
 
 def format_node(
     _node: T,
-    alias: str,
+    alias: str = "node_name",
     intermediate_node_name: bool = True,
-    style: BaseVPrintStyle = BaseVPrintStyle.from_style("const"),
+    style: Union[BaseHPrintStyle, BaseVPrintStyle] = BaseVPrintStyle.from_style(
+        "const"
+    ),
     border_style: Optional[BorderStyle] = None,
+    min_width: int = 0,
+    add_buffer: bool = True,
 ) -> List[str]:
     """Format node to be same width, able to customise whether to add border
 
     Args:
         _node (Node): node to format
-        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node.
+        alias (str): node attribute to use for node name in tree as alias to `node_name`. Otherwise, it will default to
+            `node_name` of node.
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
-        style (BaseVPrintStyle): style to format node, used only if border_style is None
+        style (Union[BaseHPrintStyle, BaseVPrintStyle]): style to format node, used only if border_style is None
         border_style (BorderStyle): border style to format node
+        min_width (int): minimum width of node display contents
+        add_buffer (bool): whether to add buffer if style is BaseHPrintStyle and border_style is None
 
     Returns:
         (List[str]) node display
@@ -52,13 +59,19 @@ def format_node(
         if border_style is None:
             node_title: str = style.BRANCH
             if _node.is_root:
-                node_title = style.SUBSEQUENT_CHILD
+                if isinstance(style, BaseHPrintStyle):
+                    node_title = style.BRANCH
+                else:
+                    node_title = style.SUBSEQUENT_CHILD
         else:
             node_title = ""
     else:
         node_title = _node.get_attr(alias) or _node.node_name
     node_title_lines = node_title.split("\n")
-    width = max([len(node_title_lines) for node_title_lines in node_title_lines])
+    width = max(
+        [len(node_title_lines) for node_title_lines in node_title_lines] + [min_width]
+    )
+    height = len(node_title_lines)
 
     node_display_lines: List[str] = []
     if border_style:
@@ -73,29 +86,59 @@ def format_node(
         node_display_lines.append(
             f"{border_style.BOTTOM_LEFT}{border_style.HORIZONTAL * width}{border_style.BOTTOM_RIGHT}"
         )
-        node_mid = calculate_stem_pos(width + 2)
-        # If there is a parent
-        if _node.parent:
-            node_display_lines[0] = (
-                node_display_lines[0][:node_mid]
-                + style.SPLIT_BRANCH
-                + node_display_lines[0][node_mid + 1 :]  # noqa
-            )
-        # If there are subsequent children
-        if any(_node.children):
-            node_display_lines[-1] = (
-                node_display_lines[-1][:node_mid]
-                + style.SUBSEQUENT_CHILD
-                + node_display_lines[-1][node_mid + 1 :]  # noqa
-            )
+
+        if isinstance(style, BaseHPrintStyle):
+            node_mid = calculate_stem_pos(height + 2)
+            # If there is a parent
+            if _node.parent:
+                node_display_lines[node_mid] = (
+                    style.SPLIT_BRANCH + node_display_lines[node_mid][1:]
+                )
+            # If there are subsequent children
+            if any(_node.children):
+                node_display_lines[node_mid] = (
+                    node_display_lines[node_mid][:-1] + style.SUBSEQUENT_CHILD
+                )
+        else:
+            node_mid = calculate_stem_pos(width + 2)
+            # If there is a parent
+            if _node.parent:
+                node_display_lines[0] = (
+                    node_display_lines[0][:node_mid]
+                    + style.SPLIT_BRANCH
+                    + node_display_lines[0][node_mid + 1 :]  # noqa
+                )
+            # If there are subsequent children
+            if any(_node.children):
+                node_display_lines[-1] = (
+                    node_display_lines[-1][:node_mid]
+                    + style.SUBSEQUENT_CHILD
+                    + node_display_lines[-1][node_mid + 1 :]  # noqa
+                )
     else:
         for node_title_line in node_title_lines:
             node_display_lines.append(f"{node_title_line.center(width)}")
+        if isinstance(style, BaseHPrintStyle) and add_buffer:
+            node_mid = calculate_stem_pos(height)
+            prefix_line = [" "] * height
+            prefix_line[node_mid] = style.BRANCH
+            prefix_line2 = [" "] * height
+            if intermediate_node_name or _node.is_leaf:
+                node_display_lines = horizontal_join(
+                    [prefix_line, prefix_line2, node_display_lines]
+                )
+            else:
+                prefix_line2 = prefix_line
+            # If there are subsequent children
+            if any(_node.children):
+                node_display_lines = horizontal_join(
+                    [node_display_lines, prefix_line2, prefix_line]
+                )
     return node_display_lines
 
 
-def horizontal_join(node_displays: List[List[str]], spacing: int = 2) -> List[str]:
-    """Horizontally join multiple node displays
+def horizontal_join(node_displays: List[List[str]], spacing: int = 0) -> List[str]:
+    """Horizontally join multiple node displays, for displaying tree vertically
 
     Args:
         node_displays (List[List[str]]): multiple node displays belonging to the same row
@@ -122,3 +165,22 @@ def horizontal_join(node_displays: List[List[str]], spacing: int = 2) -> List[st
                 row_display[row_idx_buffer] += spacing * space
             row_display[row_idx_buffer] += width * space
     return [row_display[k] for k in sorted(row_display)]
+
+
+def vertical_join(node_displays: List[List[str]]) -> List[str]:
+    """Vertically join multiple node displays, for displaying tree horizontally
+
+    Args:
+        node_displays (List[List[str]]): multiple node displays belonging to the same column
+
+    Returns:
+        (List[str]) node display of the row
+    """
+    space = " "
+    width = max([len(node_display[0]) for node_display in node_displays])
+    rows_display = []
+    for node_display in node_displays:
+        for node_display_row in node_display:
+            spacing = width - len(node_display_row)
+            rows_display.append(node_display_row + spacing * space)
+    return rows_display

--- a/bigtree/tree/export/stdout.py
+++ b/bigtree/tree/export/stdout.py
@@ -527,6 +527,7 @@ def hyield_tree(
 
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
     - Able to customize for maximum depth to print, using `max_depth`
+    - Able to hide names of intermediate nodes, using `intermediate_node_name`
     - Able to customize style, to choose from str, List[str], or inherit from constants.BaseHPrintStyle, using `style`
 
     For style,

--- a/bigtree/tree/export/stdout.py
+++ b/bigtree/tree/export/stdout.py
@@ -394,18 +394,25 @@ def yield_tree(
 
 def hprint_tree(
     tree: T,
+    alias: str = "node_name",
     node_name_or_path: str = "",
     max_depth: int = 0,
     intermediate_node_name: bool = True,
     style: Union[str, Iterable[str], constants.BaseHPrintStyle] = "const",
+    border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
+    strip: bool = True,
     **kwargs: Any,
 ) -> None:
     """Print tree in horizontal orientation to console, starting from `tree`.
     Accepts kwargs for print() function.
 
+    - Able to have alias for node name if alias attribute is present, else it falls back to node_name, using `alias`
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
     - Able to customize for maximum depth to print, using `max_depth`
     - Able to customize style, to choose from str, List[str], or inherit from constants.BaseHPrintStyle, using `style`
+    - Able to toggle border, with border style to choose from str, Iterable[str], or inherit from constants.BorderStyle,
+        using `border_style`
+    - Able to have constant width output string or to strip the trailing spaces, using `strip`
 
     For style,
 
@@ -501,34 +508,48 @@ def hprint_tree(
 
     Args:
         tree (Node): tree to print
+        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
+            Otherwise, it will default to `node_name` of node.
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
         style (Union[str, Iterable[str], constants.BaseHPrintStyle]): style of print, defaults to const
+        border_style (Union[str, Iterable[str], constants.BorderStyle]): style of border, defaults to None
+        strip (bool): whether to strip results, defaults to True
     """
     result = hyield_tree(
         tree,
+        alias=alias,
         node_name_or_path=node_name_or_path,
         intermediate_node_name=intermediate_node_name,
         max_depth=max_depth,
         style=style,
+        border_style=border_style,
+        strip=strip,
     )
     print("\n".join(result), **kwargs)
 
 
 def hyield_tree(
     tree: T,
+    alias: str = "node_name",
     node_name_or_path: str = "",
     max_depth: int = 0,
     intermediate_node_name: bool = True,
     style: Union[str, Iterable[str], constants.BaseHPrintStyle] = "const",
+    border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = "const",
+    strip: bool = True,
 ) -> List[str]:
     """Yield tree in horizontal orientation to console, starting from `tree`.
 
+    - Able to have alias for node name if alias attribute is present, else it falls back to node_name, using `alias`
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
     - Able to customize for maximum depth to print, using `max_depth`
     - Able to hide names of intermediate nodes, using `intermediate_node_name`
     - Able to customize style, to choose from str, List[str], or inherit from constants.BaseHPrintStyle, using `style`
+    - Able to toggle border, with border style to choose from str, Iterable[str], or inherit from constants.BorderStyle,
+        using `border_style`
+    - Able to have constant width output string or to strip the trailing spaces, using `strip`
 
     For style,
 
@@ -623,16 +644,24 @@ def hyield_tree(
 
     Args:
         tree (Node): tree to print
+        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
+            Otherwise, it will default to `node_name` of node.
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
         style (Union[str, Iterable[str], constants.BaseHPrintStyle]): style of print, defaults to const
+        border_style (Union[str, Iterable[str], constants.BorderStyle]): style of border, defaults to None
+        strip (bool): whether to strip results, defaults to True
 
     Returns:
         (List[str])
     """
-    from itertools import accumulate
-
+    from bigtree.tree.export._stdout import (
+        calculate_stem_pos,
+        format_node,
+        horizontal_join,
+        vertical_join,
+    )
     from bigtree.tree.helper import get_subtree
 
     tree = get_subtree(tree, node_name_or_path, max_depth)
@@ -647,13 +676,36 @@ def hyield_tree(
             raise ValueError("Please specify the style of 7 icons in `style`")
         style_class = constants.BaseHPrintStyle(*style)
 
+    if border_style is None:
+        border_style_class = None
+    elif isinstance(border_style, str):
+        border_style_class = constants.BorderStyle.from_style(border_style)
+    elif isinstance(border_style, constants.BorderStyle):
+        border_style_class = border_style
+    else:
+        if len(list(border_style)) != 6:
+            raise ValueError("Please specify the style of 6 icons in `border_style`")
+        border_style_class = constants.BorderStyle(*border_style)
+
     # Calculate padding
     space = " "
     padding_depths = collections.defaultdict(int)
     if intermediate_node_name:
         for _idx, _children in enumerate(iterators.levelordergroup_iter(tree)):
             padding_depths[_idx + 1] = max(
-                [len(_node.node_name) for _node in _children]
+                [
+                    len(
+                        format_node(
+                            _node,
+                            alias,
+                            intermediate_node_name,
+                            style_class,
+                            border_style_class,
+                            add_buffer=False,
+                        )[0]
+                    )
+                    for _node in _children
+                ]
             )
 
     def _hprint_branch(
@@ -671,97 +723,93 @@ def hyield_tree(
         """
         if not _node:
             # For binary node
-            _node = node.Node("  ")
-        node_name_centered = _node.node_name.center(padding_depths[_cur_depth])
+            _node = node.Node(" ")
+        node_display_lines = format_node(
+            _node,
+            alias,
+            intermediate_node_name,
+            style_class,
+            border_style_class,
+            padding_depths[_cur_depth],
+        )
+        node_mid = calculate_stem_pos(len(node_display_lines))
 
         children = list(_node.children) if any(list(_node.children)) else []
         if not len(children):
-            node_str = f"{style_class.BRANCH} {node_name_centered.rstrip()}"
-            return [node_str], 0
+            return node_display_lines, node_mid
 
-        result_children, result_nrow, result_idx = [], [], []
-        if intermediate_node_name:
-            node_str = (
-                f"""{style_class.BRANCH} {node_name_centered} {style_class.BRANCH}"""
-            )
-        else:
-            node_str = (
-                f"""{style_class.BRANCH}{style_class.BRANCH}{style_class.BRANCH}"""
-            )
-        padding = space * len(node_str)
+        result_children, result_idx = [], []
+        cumulative_height = 0
         for idx, child in enumerate(children):
             result_child, result_branch_idx = _hprint_branch(child, _cur_depth + 1)
-            result_children.extend(result_child)
-            result_nrow.append(len(result_child))
-            result_idx.append(result_branch_idx)
+            result_idx.append(cumulative_height + result_branch_idx)
+            cumulative_height += len(result_child)
+            result_children.append(result_child)
+
+        # Join children column
+        children_display_lines = vertical_join(result_children)
 
         # Calculate index of first branch, last branch, total length, and midpoint
         first, last, total = (
             result_idx[0],
-            sum(result_nrow) + result_idx[-1] - result_nrow[-1],
-            sum(result_nrow) - 1,
+            result_idx[-1],
+            len(children_display_lines),
         )
         mid = (first + last) // 2
 
         if len(children) == 1:
             # Special case for one child (need only one branch)
             result_prefix = (
-                [padding + space] * first
-                + [node_str + style_class.BRANCH]
-                + [padding + space] * (total - last)
+                space * first + style_class.BRANCH + space * (total - first - 1)
             )
-        elif len(children) == 2:
+        elif len(children) == 2 and (last - first == 1):
             # Special case for two children (need split_branch)
-            if last - first == 1:
-                # Create gap if two children occupy two rows
-                assert len(result_children) == 2
-                result_children = [result_children[0], "", result_children[1]]
-                last = total = first + 2
-                mid = (last - first) // 2
+            # Create gap if two children occupy two rows
+            children_display_lines.insert(last, "")
+            last = first + 2
+            mid = (last - first) // 2
             result_prefix = (
-                [padding + space] * first
-                + [padding + style_class.FIRST_CHILD]
-                + [padding + style_class.STEM] * (mid - first - 1)
-                + [node_str + style_class.SPLIT_BRANCH]
-                + [padding + style_class.STEM] * (last - mid - 1)
-                + [padding + style_class.LAST_CHILD]
-                + [padding + space] * (total - last)
+                space * first
+                + style_class.FIRST_CHILD
+                + style_class.SPLIT_BRANCH
+                + style_class.LAST_CHILD
             )
         else:
-            branch_idxs = list(
-                (
-                    offset + blanks
-                    for offset, blanks in zip(
-                        result_idx, [0] + list(accumulate(result_nrow))
-                    )
+            result_prefix = space * first + style_class.FIRST_CHILD
+            for idx, (bef, aft) in enumerate(zip(result_idx, result_idx[1:])):
+                result_prefix += style_class.STEM * (aft - bef - 1)
+                result_prefix += style_class.SUBSEQUENT_CHILD
+            result_prefix = result_prefix[:-1] + style_class.LAST_CHILD
+            result_prefix += space * (total - result_idx[-1] - 1)
+            if mid in result_idx:
+                stem = style_class.MIDDLE_CHILD if mid else style_class.FIRST_CHILD
+                result_prefix = (
+                    result_prefix[:mid] + stem + result_prefix[mid + 1 :]  # noqa
                 )
-            )
-            n_stems = [(b - a - 1) for a, b in zip(branch_idxs, branch_idxs[1:])]
-            result_prefix = (
-                [padding + space] * first
-                + [padding + style_class.FIRST_CHILD]
-                + [
-                    _line
-                    for line in [
-                        [padding + style_class.STEM] * n_stem
-                        + [padding + style_class.SUBSEQUENT_CHILD]
-                        for n_stem in n_stems[:-1]
-                    ]
-                    for _line in line
-                ]
-                + [padding + style_class.STEM] * n_stems[-1]
-                + [padding + style_class.LAST_CHILD]
-                + [padding + space] * (total - last)
-            )
-            result_prefix[mid] = node_str + style_class.SPLIT_BRANCH
-            if mid in branch_idxs:
-                result_prefix[mid] = node_str + style_class.MIDDLE_CHILD
-        result_children = [
-            prefix + stem for prefix, stem in zip(result_prefix, result_children)
-        ]
-        return result_children, mid
+            else:
+                result_prefix = (
+                    result_prefix[:mid]
+                    + style_class.SPLIT_BRANCH
+                    + result_prefix[mid + 1 :]  # noqa
+                )
+        parent_buffer = max(0, mid - node_mid)
+        child_buffer = max(0, node_mid - mid)
+        mid += child_buffer
+        node_display_lines = [
+            len(node_display_lines[0]) * space
+        ] * parent_buffer + node_display_lines
+        result_prefix = " " * child_buffer + result_prefix
+        children_display_lines = [
+            len(children_display_lines[0]) * space
+        ] * child_buffer + children_display_lines
+        result = horizontal_join(
+            [node_display_lines, list(result_prefix), children_display_lines]
+        )
+        return result, mid
 
     result_tree, _ = _hprint_branch(tree, 1)
+    if strip:
+        return [result.rstrip() for result in result_tree]
     return result_tree
 
 

--- a/bigtree/tree/export/stdout.py
+++ b/bigtree/tree/export/stdout.py
@@ -766,9 +766,11 @@ def hyield_tree(
 
 def vprint_tree(
     tree: T,
+    alias: str = "node_name",
     node_name_or_path: str = "",
     max_depth: int = 0,
     intermediate_node_name: bool = True,
+    spacing: int = 2,
     style: Union[str, Iterable[str], constants.BaseVPrintStyle] = "const",
     border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = "const",
     strip: bool = False,
@@ -777,11 +779,15 @@ def vprint_tree(
     """Print tree in vertical orientation to console, starting from `tree`.
     Accepts kwargs for print() function.
 
+    - Able to have alias for node name if alias attribute is present, else it falls back to node_name, using `alias`
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
     - Able to customize for maximum depth to print, using `max_depth`
+    - Able to hide names of intermediate nodes, using `intermediate_node_name`
+    - Able to select spacing between nodes, using `spacing`
     - Able to customize style, to choose from str, Iterable[str], or inherit from constants.BaseVPrintStyle, using `style`
     - Able to toggle border, with border style to choose from str, Iterable[str], or inherit from constants.BorderStyle,
         using `border_style`
+    - Able to have constant width output string or to strip the trailing spaces, using `strip`
 
     For style,
 
@@ -955,9 +961,12 @@ def vprint_tree(
 
     Args:
         tree (Node): tree to print
+        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
+            Otherwise, it will default to `node_name` of node.
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
+        spacing (int): spacing between node displays
         style (Union[str, Iterable[str], constants.BaseVPrintStyle]): style of print, defaults to const
         border_style (Union[str, Iterable[str], constants.BorderStyle]): style of border, defaults to const
         strip (bool): whether to strip results, defaults to False
@@ -967,9 +976,11 @@ def vprint_tree(
     """
     result = vyield_tree(
         tree,
+        alias=alias,
         node_name_or_path=node_name_or_path,
-        intermediate_node_name=intermediate_node_name,
         max_depth=max_depth,
+        intermediate_node_name=intermediate_node_name,
+        spacing=spacing,
         style=style,
         border_style=border_style,
         strip=strip,
@@ -993,15 +1004,18 @@ def vyield_tree(
     - Able to have alias for node name if alias attribute is present, else it falls back to node_name, using `alias`
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
     - Able to customize for maximum depth to print, using `max_depth`
+    - Able to hide names of intermediate nodes, using `intermediate_node_name`
+    - Able to select spacing between nodes, using `spacing`
     - Able to customize style, to choose from str, Iterable[str], or inherit from constants.BaseVPrintStyle, using `style`
     - Able to toggle border, with border style to choose from str, Iterable[str], or inherit from constants.BorderStyle,
         using `border_style`
+    - Able to have constant width output string or to strip the trailing spaces, using `strip`
 
     For style,
 
     - (str): `ansi`, `ascii`, `const` (default), `const_bold`, `rounded`, `double`  style
     - (Iterable[str]): Choose own style icons, they must be 1 character long
-    - (constants.BaseHPrintStyle): `ANSIVPrintStyle`, `ASCIIVPrintStyle`, `ConstVPrintStyle`, `ConstBoldVPrintStyle`,
+    - (constants.BaseVPrintStyle): `ANSIVPrintStyle`, `ASCIIVPrintStyle`, `ConstVPrintStyle`, `ConstBoldVPrintStyle`,
         `RoundedVPrintStyle`, `DoubleVPrintStyle` style or inherit from constants.BaseVPrintStyle
 
     For border_style,

--- a/bigtree/tree/export/stdout.py
+++ b/bigtree/tree/export/stdout.py
@@ -495,6 +495,19 @@ def hprint_tree(
         - a -+     \\- e
              \\- c
 
+        **Border**
+
+        >>> hprint_tree(root, style="rounded", border_style="rounded")
+                            ╭───────╮
+                  ╭───────╮╭┤   d   │
+                 ╭┤   b   ├┤╰───────╯
+        ╭───────╮│╰───────╯│╭───────╮
+        │   a   ├┤         ╰┤   e   │
+        ╰───────╯│          ╰───────╯
+                 │╭───────╮
+                 ╰┤   c   │
+                  ╰───────╯
+
         **Printing to a file**
         >>> import io
         >>> output = io.StringIO()
@@ -537,7 +550,7 @@ def hyield_tree(
     max_depth: int = 0,
     intermediate_node_name: bool = True,
     style: Union[str, Iterable[str], constants.BaseHPrintStyle] = "const",
-    border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = "const",
+    border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
     strip: bool = True,
 ) -> List[str]:
     """Yield tree in horizontal orientation to console, starting from `tree`.
@@ -641,6 +654,20 @@ def hyield_tree(
              /- b -+
         - a -+     \\- e
              \\- c
+
+        **Border**
+
+        >>> result = hyield_tree(root, style="rounded", border_style="rounded")
+        >>> print("\\n".join(result))
+                            ╭───────╮
+                  ╭───────╮╭┤   d   │
+                 ╭┤   b   ├┤╰───────╯
+        ╭───────╮│╰───────╯│╭───────╮
+        │   a   ├┤         ╰┤   e   │
+        ╰───────╯│          ╰───────╯
+                 │╭───────╮
+                 ╰┤   c   │
+                  ╰───────╯
 
     Args:
         tree (Node): tree to print
@@ -976,19 +1003,19 @@ def vprint_tree(
 
         **Custom Styles**
 
-        >>> from bigtree import ANSIVPrintStyle, ANSIBorderStyle
-        >>> vprint_tree(root, style=ANSIVPrintStyle, border_style=ANSIBorderStyle, strip=True)
-                `---`
-                | a |
-                `-+-`
-             /----+-----\\
-           `-+-`      `-+-`
-           | b |      | c |
-           `-+-`      `---`
-          /--+---\\
-        `-+-`  `-+-`
-        | d |  | e |
-        `---`  `---`
+        >>> from bigtree import RoundedVPrintStyle, RoundedBorderStyle
+        >>> vprint_tree(root, style=RoundedVPrintStyle, border_style=RoundedBorderStyle, strip=True)
+                ╭───╮
+                │ a │
+                ╰─┬─╯
+             ╭────┴─────╮
+           ╭─┴─╮      ╭─┴─╮
+           │ b │      │ c │
+           ╰─┬─╯      ╰───╯
+          ╭──┴───╮
+        ╭─┴─╮  ╭─┴─╮
+        │ d │  │ e │
+        ╰───╯  ╰───╯
 
         **Printing to a file**
         >>> import io
@@ -1207,20 +1234,20 @@ def vyield_tree(
 
         **Custom Styles**
 
-        >>> from bigtree import ANSIVPrintStyle, ANSIBorderStyle
-        >>> result = vyield_tree(root, style=ANSIVPrintStyle, border_style=ANSIBorderStyle, strip=True)
+        >>> from bigtree import RoundedVPrintStyle, RoundedBorderStyle
+        >>> result = vyield_tree(root, style=RoundedVPrintStyle, border_style=RoundedBorderStyle, strip=True)
         >>> print("\\n".join(result))
-                `---`
-                | a |
-                `-+-`
-             /----+-----\\
-           `-+-`      `-+-`
-           | b |      | c |
-           `-+-`      `---`
-          /--+---\\
-        `-+-`  `-+-`
-        | d |  | e |
-        `---`  `---`
+                ╭───╮
+                │ a │
+                ╰─┬─╯
+             ╭────┴─────╮
+           ╭─┴─╮      ╭─┴─╮
+           │ b │      │ c │
+           ╰─┬─╯      ╰───╯
+          ╭──┴───╮
+        ╭─┴─╮  ╭─┴─╮
+        │ d │  │ e │
+        ╰───╯  ╰───╯
 
     Args:
         tree (Node): tree to print

--- a/docs/bigtree/tree/export.md
+++ b/docs/bigtree/tree/export.md
@@ -28,8 +28,8 @@ While exporting to another data type, methods can take in arguments to determine
 |------------------------|-------------------------------------|-----------------------|------------|---------------------------------------|-------------------------------------------------------|
 | `print_tree`           | Yes with `attr_list` or `all_attrs` | Yes                   | No         | No                                    | Tree style                                            |
 | `yield_tree`           | No, returns node                    | Yes                   | No         | No                                    | Tree style                                            |
-| `hprint_tree`          | No                                  | Yes                   | No         | Yes, by hiding intermediate node name | Tree style                                            |
-| `hyield_tree`          | No                                  | Yes                   | No         | Yes, by hiding intermediate node name | Tree style                                            |
+| `hprint_tree`          | No                                  | Yes                   | No         | Yes, by hiding intermediate node name | Tree style, border style                              |
+| `hyield_tree`          | No                                  | Yes                   | No         | Yes, by hiding intermediate node name | Tree style, border style                              |
 | `vprint_tree`          | No                                  | Yes                   | No         | Yes, by hiding intermediate node name | Tree style, border style                              |
 | `vyield_tree`          | No                                  | Yes                   | No         | Yes, by hiding intermediate node name | Tree style, border style                              |
 | `tree_to_newick`       | Yes with `attr_list`                | No                    | No         | Yes, by hiding intermediate node name | Length separator and attribute prefix and separator   |

--- a/docs/gettingstarted/demo/tree.md
+++ b/docs/gettingstarted/demo/tree.md
@@ -339,12 +339,12 @@ Construct nodes with attributes. *DataFrame* can contain either <mark>path colum
 
 ### 1. Print Tree
 
-After tree is constructed, it can be viewed by printing to console using `show` or `hshow` method directly,
-for vertical and horizontal orientation respectively.
-Alternatively, the `print_tree` or `hprint_tree` method can be used.
+After tree is constructed, it can be viewed by printing to console using `show`, `hshow`, or `vshow` method directly,
+for compact, horizontal, and vertical orientation respectively.
+Alternatively, the `print_tree`, `hprint_tree`, or `vprint_tree` method can be used.
 
 ```python hl_lines="8 15"
-from bigtree import Node, print_tree, hprint_tree
+from bigtree import Node, print_tree, hprint_tree, vprint_tree
 
 root = Node("a", alias="alias-a", age=90, gender="F")
 b = Node("b", age=65, gender="M", parent=root)
@@ -363,17 +363,31 @@ hprint_tree(root) # (2)!
 #      ┌─ b ─┤
 # ─ a ─┤     └─ e
 #      └─ c
+
+vprint_tree(root) # (3)!
+#         ┌───┐
+#         │ a │
+#         └─┬─┘
+#      ┌────┴─────┐
+#    ┌─┴─┐      ┌─┴─┐
+#    │ b │      │ c │
+#    └─┬─┘      └───┘
+#   ┌──┴───┐
+# ┌─┴─┐  ┌─┴─┐
+# │ d │  │ e │
+# └───┘  └───┘
 ```
 
 1. Alternatively, `root.show()` can be used
 2. Alternatively, `root.hshow()` can be used
+3. Alternatively, `root.vshow()` can be used
 
 Other customizations for printing are also available, such as:
 
 - Printing alias instead of node name, if present
 - Printing subtree
 - Printing tree with attributes
-- Different built-in or custom style
+- Different built-in or custom style and border style
 
 === "Alias"
     ```python hl_lines="1"
@@ -572,6 +586,7 @@ Below is the table of operations available to `BaseNode` and `Node` classes.
 |-------------------------------------------------|------------------------------------------------------------|--------------------------------------------|
 | Visualize tree (only for `Node`)                | `root.show()`                                              | None                                       |
 | Visualize tree (horizontally) (only for `Node`) | `root.hshow()`                                             | None                                       |
+| Visualize tree (vertically) (only for `Node`)   | `root.vshow()`                                             | None                                       |
 | Get node information                            | `root.describe(exclude_prefix="_")`                        | [('name', 'a')]                            |
 | Find path from one node to another              | `root.go_to(node_e)`                                       | [Node(/a, ), Node(/a/b, ), Node(/a/b/e, )] |
 | Add child to node                               | `root.append(Node("j"))`                                   | None                                       |

--- a/docs/home/tree.md
+++ b/docs/home/tree.md
@@ -53,7 +53,7 @@ For **Tree** implementation, there are 9 main components.
 - Plot tree using matplotlib (optional dependency)
 
 ## [**🔨 Exporting Tree**](../bigtree/tree/export.md)
-- Print to console, in vertical or horizontal orientation
+- Print to console, in compact, vertical, or horizontal orientation
 - Export to *Newick string notation*, *dictionary*, *nested dictionary*, *pandas DataFrame*, or *polars DataFrame*
 - Export tree to *dot* (can save to .dot, .png, .svg, .jpeg files)
 - Export tree to *Pillow* (can save to .png, .jpg)

--- a/tests/node/test_binarynode.py
+++ b/tests/node/test_binarynode.py
@@ -1014,7 +1014,7 @@ def assert_binarytree_structure_root2(root):
     expected_str = (
         "                 ┌─ 8\n"
         "           ┌─ 4 ─┤\n"
-        "     ┌─ 2 ─┤     └─ \n"
+        "     ┌─ 2 ─┤     └─\n"
         "─ 1 ─┤     └─ 5\n"
         "     │     ┌─ 6\n"
         "     └─ 3 ─┤\n"

--- a/tests/tree/export/test_stdout.py
+++ b/tests/tree/export/test_stdout.py
@@ -977,32 +977,6 @@ class TestVPrintTree:
     @staticmethod
     def test_vprint_tree_spacing(tree_node):
         expected_str = (
-            "             ┌───┐\n"
-            "             │ a │\n"
-            "             └─┬─┘\n"
-            "       ┌───────┴───────┐\n"
-            "     ┌─┴─┐           ┌─┴─┐\n"
-            "     │ b │           │ c │\n"
-            "     └─┬─┘           └─┬─┘\n"
-            "  ┌────┴────┐          │\n"
-            "┌─┴─┐     ┌─┴─┐      ┌─┴─┐\n"
-            "│ d │     │ e │      │ f │\n"
-            "└───┘     └─┬─┘      └───┘\n"
-            "         ┌──┴───┐\n"
-            "       ┌─┴─┐  ┌─┴─┐\n"
-            "       │ g │  │ h │\n"
-            "       └───┘  └───┘\n"
-        )
-        assert_print_statement(
-            export.vprint_tree,
-            expected_str,
-            tree=tree_node,
-            spacing=4,
-        )
-
-    @staticmethod
-    def test_vprint_tree_strip(tree_node):
-        expected_str = (
             "                ┌───┐           \n"
             "                │ a │           \n"
             "                └─┬─┘           \n"
@@ -1018,6 +992,32 @@ class TestVPrintTree:
             "         ┌─┴─┐    ┌─┴─┐         \n"
             "         │ g │    │ h │         \n"
             "         └───┘    └───┘         \n"
+        )
+        assert_print_statement(
+            export.vprint_tree,
+            expected_str,
+            tree=tree_node,
+            spacing=4,
+        )
+
+    @staticmethod
+    def test_vprint_tree_strip(tree_node):
+        expected_str = (
+            "             ┌───┐\n"
+            "             │ a │\n"
+            "             └─┬─┘\n"
+            "       ┌───────┴───────┐\n"
+            "     ┌─┴─┐           ┌─┴─┐\n"
+            "     │ b │           │ c │\n"
+            "     └─┬─┘           └─┬─┘\n"
+            "  ┌────┴────┐          │\n"
+            "┌─┴─┐     ┌─┴─┐      ┌─┴─┐\n"
+            "│ d │     │ e │      │ f │\n"
+            "└───┘     └─┬─┘      └───┘\n"
+            "         ┌──┴───┐\n"
+            "       ┌─┴─┐  ┌─┴─┐\n"
+            "       │ g │  │ h │\n"
+            "       └───┘  └───┘\n"
         )
         assert_print_statement(
             export.vprint_tree,

--- a/tests/tree/export/test_stdout.py
+++ b/tests/tree/export/test_stdout.py
@@ -914,6 +914,36 @@ class TestVPrintTree:
         )
 
     @staticmethod
+    def test_vprint_tree_multiline(tree_node):
+        tree_node.name = "a\na2"
+        tree_node["b"]["e"].name = "e\ne2\neeeeee3"
+        expected_str = (
+            "             ┌────┐       \n"
+            "             │ a  │       \n"
+            "             │ a2 │       \n"
+            "             └─┬──┘       \n"
+            "       ┌───────┴───────┐  \n"
+            "     ┌─┴─┐           ┌─┴─┐\n"
+            "     │ b │           │ c │\n"
+            "     └─┬─┘           └─┬─┘\n"
+            "  ┌────┴────┐          │  \n"
+            "┌─┴─┐  ┌────┴────┐   ┌─┴─┐\n"
+            "│ d │  │    e    │   │ f │\n"
+            "└───┘  │    e2   │   └───┘\n"
+            "       │ eeeeee3 │        \n"
+            "       └────┬────┘        \n"
+            "         ┌──┴───┐         \n"
+            "       ┌─┴─┐  ┌─┴─┐       \n"
+            "       │ g │  │ h │       \n"
+            "       └───┘  └───┘       \n"
+        )
+        assert_print_statement(
+            export.vprint_tree,
+            expected_str,
+            tree=tree_node,
+        )
+
+    @staticmethod
     def test_vprint_tree_alias(tree_node):
         tree_node.alias_attr = "a\na2"
         tree_node["b"]["e"].alias_attr = "e\ne2\neeeeee3"
@@ -945,37 +975,7 @@ class TestVPrintTree:
         )
 
     @staticmethod
-    def test_vprint_tree_multiline(tree_node):
-        tree_node.name = "a\na2"
-        tree_node["b"]["e"].name = "e\ne2\neeeeee3"
-        expected_str = (
-            "             ┌────┐       \n"
-            "             │ a  │       \n"
-            "             │ a2 │       \n"
-            "             └─┬──┘       \n"
-            "       ┌───────┴───────┐  \n"
-            "     ┌─┴─┐           ┌─┴─┐\n"
-            "     │ b │           │ c │\n"
-            "     └─┬─┘           └─┬─┘\n"
-            "  ┌────┴────┐          │  \n"
-            "┌─┴─┐  ┌────┴────┐   ┌─┴─┐\n"
-            "│ d │  │    e    │   │ f │\n"
-            "└───┘  │    e2   │   └───┘\n"
-            "       │ eeeeee3 │        \n"
-            "       └────┬────┘        \n"
-            "         ┌──┴───┐         \n"
-            "       ┌─┴─┐  ┌─┴─┐       \n"
-            "       │ g │  │ h │       \n"
-            "       └───┘  └───┘       \n"
-        )
-        assert_print_statement(
-            export.vprint_tree,
-            expected_str,
-            tree=tree_node,
-        )
-
-    @staticmethod
-    def test_vprint_tree_strip(tree_node):
+    def test_vprint_tree_spacing(tree_node):
         expected_str = (
             "             ┌───┐\n"
             "             │ a │\n"
@@ -992,6 +992,32 @@ class TestVPrintTree:
             "       ┌─┴─┐  ┌─┴─┐\n"
             "       │ g │  │ h │\n"
             "       └───┘  └───┘\n"
+        )
+        assert_print_statement(
+            export.vprint_tree,
+            expected_str,
+            tree=tree_node,
+            spacing=4,
+        )
+
+    @staticmethod
+    def test_vprint_tree_strip(tree_node):
+        expected_str = (
+            "                ┌───┐           \n"
+            "                │ a │           \n"
+            "                └─┬─┘           \n"
+            "        ┌─────────┴──────────┐  \n"
+            "      ┌─┴─┐                ┌─┴─┐\n"
+            "      │ b │                │ c │\n"
+            "      └─┬─┘                └─┬─┘\n"
+            "  ┌─────┴──────┐             │  \n"
+            "┌─┴─┐        ┌─┴─┐         ┌─┴─┐\n"
+            "│ d │        │ e │         │ f │\n"
+            "└───┘        └─┬─┘         └───┘\n"
+            "           ┌───┴────┐           \n"
+            "         ┌─┴─┐    ┌─┴─┐         \n"
+            "         │ g │    │ h │         \n"
+            "         └───┘    └───┘         \n"
         )
         assert_print_statement(
             export.vprint_tree,

--- a/tests/tree/export/test_stdout.py
+++ b/tests/tree/export/test_stdout.py
@@ -914,6 +914,37 @@ class TestVPrintTree:
         )
 
     @staticmethod
+    def test_vprint_tree_alias(tree_node):
+        tree_node.alias_attr = "a\na2"
+        tree_node["b"]["e"].alias_attr = "e\ne2\neeeeee3"
+        expected_str = (
+            "             ┌────┐       \n"
+            "             │ a  │       \n"
+            "             │ a2 │       \n"
+            "             └─┬──┘       \n"
+            "       ┌───────┴───────┐  \n"
+            "     ┌─┴─┐           ┌─┴─┐\n"
+            "     │ b │           │ c │\n"
+            "     └─┬─┘           └─┬─┘\n"
+            "  ┌────┴────┐          │  \n"
+            "┌─┴─┐  ┌────┴────┐   ┌─┴─┐\n"
+            "│ d │  │    e    │   │ f │\n"
+            "└───┘  │    e2   │   └───┘\n"
+            "       │ eeeeee3 │        \n"
+            "       └────┬────┘        \n"
+            "         ┌──┴───┐         \n"
+            "       ┌─┴─┐  ┌─┴─┐       \n"
+            "       │ g │  │ h │       \n"
+            "       └───┘  └───┘       \n"
+        )
+        assert_print_statement(
+            export.vprint_tree,
+            expected_str,
+            tree=tree_node,
+            alias="alias_attr",
+        )
+
+    @staticmethod
     def test_vprint_tree_multiline(tree_node):
         tree_node.name = "a\na2"
         tree_node["b"]["e"].name = "e\ne2\neeeeee3"

--- a/tests/tree/export/test_stdout.py
+++ b/tests/tree/export/test_stdout.py
@@ -590,6 +590,40 @@ class TestPrintTree:
         )
 
     @staticmethod
+    def test_hprint_tree_alias(tree_node):
+        tree_node.alias_attr = "a\na2"
+        tree_node["b"]["e"].alias_attr = "e\ne2\nalias_1"
+        expected_str = (
+            "            ┌─    d\n"
+            "      ┌─ b ─┤     e     ┌─ g\n"
+            "─ a  ─┤     └─    e2   ─┤\n"
+            "  a2  │        alias_1  └─ h\n"
+            "      └─ c ───    f\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            alias="alias_attr",
+        )
+
+    @staticmethod
+    def test_hprint_tree_strip(tree_node):
+        expected_str = (
+            "           ┌─ d      \n"
+            "     ┌─ b ─┤     ┌─ g\n"
+            "─ a ─┤     └─ e ─┤   \n"
+            "     │           └─ h\n"
+            "     └─ c ─── f      \n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            strip=False,
+        )
+
+    @staticmethod
     def test_hprint_tree_long_root_name_length(tree_node):
         tree_node.name = "abcdefghijkl"
         expected_str = (
@@ -870,7 +904,7 @@ class TestPrintTree:
         )
 
     @staticmethod
-    def test_hprint_tree_style_class_error(tree_node):
+    def test_hprint_tree_style_class_unequal_char_error(tree_node):
         from bigtree.utils.constants import BaseHPrintStyle
 
         with pytest.raises(ValueError) as exc_info:
@@ -924,9 +958,57 @@ class TestPrintTree:
         export.hprint_tree(tree_node, file=output)
         assert output.getvalue() == tree_node_hstr
 
-    # border
+    # border_style
     @staticmethod
-    def test_hprint_tree_border(tree_node):
+    def test_hprint_tree_border_style_ansi(tree_node):
+        expected_str = (
+            "                    `-------`\n"
+            "                   /+   d   |\n"
+            "          `-------`|`-------`\n"
+            "         /+   b   ++          `-------`\n"
+            "         |`-------`|`-------`/+   g   |\n"
+            "`-------`|         \\+   e   ++`-------`\n"
+            "|   a   ++          `-------`|`-------`\n"
+            "`-------`|                   \\+   h   |\n"
+            "         |                    `-------`\n"
+            "         |`-------` `-------`\n"
+            "         \\+   c   +-+   f   |\n"
+            "          `-------` `-------`\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            style="ansi",
+            border_style="ansi",
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_ascii(tree_node):
+        expected_str = (
+            "                    +-------+\n"
+            "                   ++   d   |\n"
+            "          +-------+|+-------+\n"
+            "         ++   b   ++          +-------+\n"
+            "         |+-------+|+-------+++   g   |\n"
+            "+-------+|         ++   e   +++-------+\n"
+            "|   a   ++          +-------+|+-------+\n"
+            "+-------+|                   ++   h   |\n"
+            "         |                    +-------+\n"
+            "         |+-------+ +-------+\n"
+            "         ++   c   +-+   f   |\n"
+            "          +-------+ +-------+\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            style="ascii",
+            border_style="ascii",
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_const(tree_node):
         expected_str = (
             "                    ┌───────┐\n"
             "                   ┌┤   d   │\n"
@@ -945,11 +1027,119 @@ class TestPrintTree:
             export.hprint_tree,
             expected_str,
             tree=tree_node,
+            style="const",
             border_style="const",
         )
 
     @staticmethod
-    def test_vprint_tree_border_multiline(tree_node):
+    def test_hprint_tree_border_style_const_bold(tree_node):
+        expected_str = (
+            "                    ┏━━━━━━━┓\n"
+            "                   ┏┫   d   ┃\n"
+            "          ┏━━━━━━━┓┃┗━━━━━━━┛\n"
+            "         ┏┫   b   ┣┫          ┏━━━━━━━┓\n"
+            "         ┃┗━━━━━━━┛┃┏━━━━━━━┓┏┫   g   ┃\n"
+            "┏━━━━━━━┓┃         ┗┫   e   ┣┫┗━━━━━━━┛\n"
+            "┃   a   ┣┫          ┗━━━━━━━┛┃┏━━━━━━━┓\n"
+            "┗━━━━━━━┛┃                   ┗┫   h   ┃\n"
+            "         ┃                    ┗━━━━━━━┛\n"
+            "         ┃┏━━━━━━━┓ ┏━━━━━━━┓\n"
+            "         ┗┫   c   ┣━┫   f   ┃\n"
+            "          ┗━━━━━━━┛ ┗━━━━━━━┛\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            style="const_bold",
+            border_style="const_bold",
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_rounded(tree_node):
+        expected_str = (
+            "                    ╭───────╮\n"
+            "                   ╭┤   d   │\n"
+            "          ╭───────╮│╰───────╯\n"
+            "         ╭┤   b   ├┤          ╭───────╮\n"
+            "         │╰───────╯│╭───────╮╭┤   g   │\n"
+            "╭───────╮│         ╰┤   e   ├┤╰───────╯\n"
+            "│   a   ├┤          ╰───────╯│╭───────╮\n"
+            "╰───────╯│                   ╰┤   h   │\n"
+            "         │                    ╰───────╯\n"
+            "         │╭───────╮ ╭───────╮\n"
+            "         ╰┤   c   ├─┤   f   │\n"
+            "          ╰───────╯ ╰───────╯\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            style="rounded",
+            border_style="rounded",
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_double(tree_node):
+        expected_str = (
+            "                    ╔═══════╗\n"
+            "                   ╔╣   d   ║\n"
+            "          ╔═══════╗║╚═══════╝\n"
+            "         ╔╣   b   ╠╣          ╔═══════╗\n"
+            "         ║╚═══════╝║╔═══════╗╔╣   g   ║\n"
+            "╔═══════╗║         ╚╣   e   ╠╣╚═══════╝\n"
+            "║   a   ╠╣          ╚═══════╝║╔═══════╗\n"
+            "╚═══════╝║                   ╚╣   h   ║\n"
+            "         ║                    ╚═══════╝\n"
+            "         ║╔═══════╗ ╔═══════╗\n"
+            "         ╚╣   c   ╠═╣   f   ║\n"
+            "          ╚═══════╝ ╚═══════╝\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            style="double",
+            border_style="double",
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_unknown_error(tree_node):
+        with pytest.raises(ValueError) as exc_info:
+            export.hprint_tree(tree_node, border_style="something")
+        assert str(exc_info.value).startswith(
+            Constants.ERROR_NODE_EXPORT_PRINT_INVALID_STYLE
+        )
+
+    # custom border_style
+    @staticmethod
+    def test_hprint_tree_border_style_ansi_class(tree_node):
+        from bigtree.utils.constants import ANSIBorderStyle, ANSIHPrintStyle
+
+        expected_str = (
+            "                    `-------`\n"
+            "                   /+   d   |\n"
+            "          `-------`|`-------`\n"
+            "         /+   b   ++          `-------`\n"
+            "         |`-------`|`-------`/+   g   |\n"
+            "`-------`|         \\+   e   ++`-------`\n"
+            "|   a   ++          `-------`|`-------`\n"
+            "`-------`|                   \\+   h   |\n"
+            "         |                    `-------`\n"
+            "         |`-------` `-------`\n"
+            "         \\+   c   +-+   f   |\n"
+            "          `-------` `-------`\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            style=ANSIHPrintStyle,
+            border_style=ANSIBorderStyle,
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_multiline(tree_node):
         tree_node.name = "a\na2"
         tree_node["b"]["e"].name = "e\ne2\nmultiln"
         expected_str = (
@@ -974,7 +1164,7 @@ class TestPrintTree:
         )
 
     @staticmethod
-    def test_hprint_tree_border_multiline_parent_longer(tree_node):
+    def test_hprint_tree_border_style_multiline_parent_longer(tree_node):
         tree_node.name = "a\na2"
         tree_node["b"]["e"].name = "e\ne2\nmultiln\nmultiln\nmultiln"
         expected_str = (
@@ -1000,7 +1190,7 @@ class TestPrintTree:
         )
 
     @staticmethod
-    def test_hprint_tree_border_diff_node_name_length(tree_node):
+    def test_hprint_tree_border_style_diff_node_name_length(tree_node):
         tree_node["b"].name = "bcde"
         tree_node["c"]["f"].name = "fghijk"
         expected_str = (
@@ -1632,7 +1822,7 @@ class TestVPrintTree:
         )
 
     @staticmethod
-    def test_vprint_tree_style_class_error(tree_node):
+    def test_vprint_tree_style_class_unequal_char_error(tree_node):
         from bigtree.utils.constants import BaseVPrintStyle
 
         with pytest.raises(ValueError) as exc_info:
@@ -1696,7 +1886,7 @@ class TestVPrintTree:
         export.vprint_tree(tree_node, file=output)
         assert output.getvalue() == tree_node_vstr
 
-    # border
+    # border_style
     @staticmethod
     def test_vprint_tree_border_none(tree_node):
         expected_str = (

--- a/tests/tree/export/test_stdout.py
+++ b/tests/tree/export/test_stdout.py
@@ -916,7 +916,7 @@ class TestVPrintTree:
     @staticmethod
     def test_vprint_tree_multiline(tree_node):
         tree_node.name = "a\na2"
-        tree_node["b"]["e"].name = "e\ne2\neeeeee3"
+        tree_node["b"]["e"].name = "e\ne2\nmultiln"
         expected_str = (
             "             ┌────┐       \n"
             "             │ a  │       \n"
@@ -930,7 +930,7 @@ class TestVPrintTree:
             "┌─┴─┐  ┌────┴────┐   ┌─┴─┐\n"
             "│ d │  │    e    │   │ f │\n"
             "└───┘  │    e2   │   └───┘\n"
-            "       │ eeeeee3 │        \n"
+            "       │ multiln │        \n"
             "       └────┬────┘        \n"
             "         ┌──┴───┐         \n"
             "       ┌─┴─┐  ┌─┴─┐       \n"
@@ -946,7 +946,7 @@ class TestVPrintTree:
     @staticmethod
     def test_vprint_tree_alias(tree_node):
         tree_node.alias_attr = "a\na2"
-        tree_node["b"]["e"].alias_attr = "e\ne2\neeeeee3"
+        tree_node["b"]["e"].alias_attr = "e\ne2\nalias_1"
         expected_str = (
             "             ┌────┐       \n"
             "             │ a  │       \n"
@@ -960,7 +960,7 @@ class TestVPrintTree:
             "┌─┴─┐  ┌────┴────┐   ┌─┴─┐\n"
             "│ d │  │    e    │   │ f │\n"
             "└───┘  │    e2   │   └───┘\n"
-            "       │ eeeeee3 │        \n"
+            "       │ alias_1 │        \n"
             "       └────┬────┘        \n"
             "         ┌──┴───┐         \n"
             "       ┌─┴─┐  ┌─┴─┐       \n"

--- a/tests/tree/export/test_stdout.py
+++ b/tests/tree/export/test_stdout.py
@@ -456,8 +456,7 @@ class TestPrintTree:
         export.print_tree(tree_node, file=output)
         assert output.getvalue() == tree_node_no_attr_str
 
-
-class TestHPrintTree:
+    # class TestHPrintTree:
     @staticmethod
     def test_hprint_tree(tree_node):
         assert_print_statement(
@@ -528,6 +527,61 @@ class TestHPrintTree:
             "           │      ┌─ e311\n"
             "           └─ e3 ─┼─ e312\n"
             "                  └─ e313\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+        )
+
+    @staticmethod
+    def test_hprint_tree_multiline(tree_node):
+        tree_node.name = "a\na2"
+        tree_node["b"]["e"].name = "e\ne2\nmultiln"
+        expected_str = (
+            "            ┌─    d\n"
+            "      ┌─ b ─┤     e     ┌─ g\n"
+            "─ a  ─┤     └─    e2   ─┤\n"
+            "  a2  │        multiln  └─ h\n"
+            "      └─ c ───    f\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+        )
+
+    @staticmethod
+    def test_hprint_tree_multiline_parent_longer(tree_node):
+        tree_node.name = "a\na2"
+        tree_node["c"].name = "c\nc2\nmultiln"
+        expected_str = (
+            "                  ┌─ d\n"
+            "      ┌─    b    ─┤     ┌─ g\n"
+            "      │           └─ e ─┤\n"
+            "─ a  ─┤                 └─ h\n"
+            "  a2  │     c\n"
+            "      └─    c2   ─── f\n"
+            "         multiln\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+        )
+
+    @staticmethod
+    def test_hprint_tree_multiline_parent_longer2(tree_node):
+        tree_node.name = "a\na2"
+        tree_node["b"]["e"].name = "e\ne2\nmultiln\nmultiln\nmultiln"
+        expected_str = (
+            "            ┌─    d\n"
+            "      ┌─ b ─┤     e\n"
+            "      │     │     e2    ┌─ g\n"
+            "─ a  ─┤     └─ multiln ─┤\n"
+            "  a2  │        multiln  └─ h\n"
+            "      │        multiln\n"
+            "      └─ c ───    f\n"
         )
         assert_print_statement(
             export.hprint_tree,
@@ -611,6 +665,30 @@ class TestHPrintTree:
             expected_str,
             tree=tree_node,
             intermediate_node_name=False,
+        )
+
+    @staticmethod
+    def test_vprint_tree_intermediate_node_name_border(tree_node):
+        expected_str = (
+            "          ┌───┐\n"
+            "         ┌┤ d │\n"
+            "     ┌──┐│└───┘\n"
+            "    ┌┤  ├┤     ┌───┐\n"
+            "    │└──┘│┌──┐┌┤ g │\n"
+            "┌──┐│    └┤  ├┤└───┘\n"
+            "│  ├┤     └──┘│┌───┐\n"
+            "└──┘│         └┤ h │\n"
+            "    │          └───┘\n"
+            "    │┌──┐ ┌───┐\n"
+            "    └┤  ├─┤ f │\n"
+            "     └──┘ └───┘\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            intermediate_node_name=False,
+            border_style="const",
         )
 
     @staticmethod
@@ -845,6 +923,121 @@ class TestHPrintTree:
         output = io.StringIO()
         export.hprint_tree(tree_node, file=output)
         assert output.getvalue() == tree_node_hstr
+
+    # border
+    @staticmethod
+    def test_hprint_tree_border(tree_node):
+        expected_str = (
+            "                    ┌───────┐\n"
+            "                   ┌┤   d   │\n"
+            "          ┌───────┐│└───────┘\n"
+            "         ┌┤   b   ├┤          ┌───────┐\n"
+            "         │└───────┘│┌───────┐┌┤   g   │\n"
+            "┌───────┐│         └┤   e   ├┤└───────┘\n"
+            "│   a   ├┤          └───────┘│┌───────┐\n"
+            "└───────┘│                   └┤   h   │\n"
+            "         │                    └───────┘\n"
+            "         │┌───────┐ ┌───────┐\n"
+            "         └┤   c   ├─┤   f   │\n"
+            "          └───────┘ └───────┘\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            border_style="const",
+        )
+
+    @staticmethod
+    def test_vprint_tree_border_multiline(tree_node):
+        tree_node.name = "a\na2"
+        tree_node["b"]["e"].name = "e\ne2\nmultiln"
+        expected_str = (
+            "                     ┌─────────────┐\n"
+            "                    ┌┤      d      │\n"
+            "           ┌───────┐│└─────────────┘\n"
+            "          ┌┤   b   ├┤┌─────────────┐ ┌───────┐\n"
+            "          │└───────┘││      e      │┌┤   g   │\n"
+            "┌────────┐│         └┤      e2     ├┤└───────┘\n"
+            "│   a    ├┤          │   multiln   ││┌───────┐\n"
+            "│   a2   ││          └─────────────┘└┤   h   │\n"
+            "└────────┘│                          └───────┘\n"
+            "          │┌───────┐ ┌─────────────┐\n"
+            "          └┤   c   ├─┤      f      │\n"
+            "           └───────┘ └─────────────┘\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            border_style="const",
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_multiline_parent_longer(tree_node):
+        tree_node.name = "a\na2"
+        tree_node["b"]["e"].name = "e\ne2\nmultiln\nmultiln\nmultiln"
+        expected_str = (
+            "                     ┌─────────────┐\n"
+            "                    ┌┤      d      │\n"
+            "           ┌───────┐│└─────────────┘\n"
+            "          ┌┤   b   ├┤┌─────────────┐\n"
+            "          │└───────┘││      e      │ ┌───────┐\n"
+            "          │         ││      e2     │┌┤   g   │\n"
+            "┌────────┐│         └┤   multiln   ├┤└───────┘\n"
+            "│   a    ├┤          │   multiln   ││┌───────┐\n"
+            "│   a2   ││          │   multiln   │└┤   h   │\n"
+            "└────────┘│          └─────────────┘ └───────┘\n"
+            "          │┌───────┐ ┌─────────────┐\n"
+            "          └┤   c   ├─┤      f      │\n"
+            "           └───────┘ └─────────────┘\n"
+        )
+        assert_print_statement(
+            export.hprint_tree,
+            expected_str,
+            tree=tree_node,
+            border_style="const",
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_diff_node_name_length(tree_node):
+        tree_node["b"].name = "bcde"
+        tree_node["c"]["f"].name = "fghijk"
+        expected_str = (
+            "                       ┌────────────┐\n"
+            "                      ┌┤     d      │\n"
+            "          ┌──────────┐│└────────────┘\n"
+            "         ┌┤   bcde   ├┤               ┌───────┐\n"
+            "         │└──────────┘│┌────────────┐┌┤   g   │\n"
+            "┌───────┐│            └┤     e      ├┤└───────┘\n"
+            "│   a   ├┤             └────────────┘│┌───────┐\n"
+            "└───────┘│                           └┤   h   │\n"
+            "         │                            └───────┘\n"
+            "         │┌──────────┐ ┌────────────┐\n"
+            "         └┤    c     ├─┤   fghijk   │\n"
+            "          └──────────┘ └────────────┘\n"
+        )
+        assert_print_statement(
+            export.hprint_tree, expected_str, tree=tree_node, border_style="const"
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_unequal_char_error(tree_node):
+        with pytest.raises(ValueError) as exc_info:
+            export.hprint_tree(
+                tree_node,
+                border_style=["+ ", "+", "+", "+", "|", "-"],
+            )
+        assert (
+            str(exc_info.value)
+            == Constants.ERROR_NODE_EXPORT_HPRINT_CUSTOM_STYLE_DIFFERENT_LENGTH
+        )
+
+    @staticmethod
+    def test_hprint_tree_border_style_missing_style_error(tree_node):
+        with pytest.raises(ValueError) as exc_info:
+            export.hprint_tree(tree_node, border_style=["+", "+", "+", "+", "|"])
+        assert str(exc_info.value) == Constants.ERROR_NODE_EXPORT_BORDER_STYLE_SELECT
 
 
 class TestVPrintTree:

--- a/tests/tree/export/test_stdout.py
+++ b/tests/tree/export/test_stdout.py
@@ -702,7 +702,7 @@ class TestPrintTree:
         )
 
     @staticmethod
-    def test_vprint_tree_intermediate_node_name_border(tree_node):
+    def test_hprint_tree_intermediate_node_name_border(tree_node):
         expected_str = (
             "          ┌───┐\n"
             "         ┌┤ d │\n"


### PR DESCRIPTION
## Description
This also affects hyield_tree, hprint_tree and tree.hshow(). Note that by default strip=True for backwards compatibility, compared to strip=False in vprint, and also by default the root node will have a "prefix"

## Testing
Added tests similar to vprint_tree

## Additional notes
<!-- Any information that might be useful for review -->

## Checklist
I have read through the [contributing guidelines](https://bigtree.readthedocs.io/en/stable/home/contributing/) and ensured that
- [x] I have added a descriptive title for this pull request.
- [x] I have followed the convention and standards, and my code is checked for style and correctness.
- [x] I have added test cases, and unit tests pass with 100% code coverage.
- [x] I have updated the documentation and code docstrings.

## Checklist (for reviewer)
- [x] I have added label (breaking / enhancement / bug / documentation) to this pull request, if applicable.
- [x] I will ensure this change is captured in the *CHANGELOG.md* file.
