### PR TITLE
Deduplicate docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
-- Everything: Clean up repository by abstracting functions into inheritable classes, deduplicate type hints in docstrings.
+- Docs: Deduplicate type hint and default value in docstrings.
+- Misc: Clean up repository by abstracting functions into inheritable classes.
 
 ## [0.25.2] - 2025-03-14
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.25.2] - 2025-03-14
 ### Added:
 - Tree Exporter: `hprint_tree` and `hyield_tree` to support spacing parameter.
 ### Fixed:
@@ -745,7 +747,8 @@ ignore null attribute columns.
 - Utility Iterator: Tree traversal methods.
 - Workflow To Do App: Tree use case with to-do list implementation.
 
-[Unreleased]: https://github.com/kayjan/bigtree/compare/0.25.1...HEAD
+[Unreleased]: https://github.com/kayjan/bigtree/compare/0.25.2...HEAD
+[0.25.2]: https://github.com/kayjan/bigtree/compare/0.25.1...0.25.2
 [0.25.1]: https://github.com/kayjan/bigtree/compare/0.25.0...0.25.1
 [0.25.0]: https://github.com/kayjan/bigtree/compare/0.24.0...0.25.0
 [0.24.0]: https://github.com/kayjan/bigtree/compare/0.23.1...0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Everything: Clean up repository by abstracting functions into inheritable classes, deduplicate type hints in docstrings.
 
 ## [0.25.2] - 2025-03-14
 ### Added:

--- a/bigtree/__init__.py
+++ b/bigtree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.25.1"
+__version__ = "0.25.2"
 
 from bigtree.binarytree.construct import list_to_binarytree
 from bigtree.dag.construct import dataframe_to_dag, dict_to_dag, list_to_dag

--- a/bigtree/binarytree/construct.py
+++ b/bigtree/binarytree/construct.py
@@ -35,11 +35,11 @@ def list_to_binarytree(
         ![Sample Binary Tree](https://github.com/kayjan/bigtree/raw/master/assets/construct_binarytree.png)
 
     Args:
-        heapq_list (List[int]): list containing integer node names, ordered in heapq fashion
-        node_type (Type[BinaryNode]): node type of tree to be created, defaults to ``BinaryNode``
+        heapq_list: list containing integer node names, ordered in heapq fashion
+        node_type: node type of tree to be created
 
     Returns:
-        (BinaryNode)
+        Binary node
     """
     assertions.assert_length_not_empty(heapq_list, "Input list", "heapq_list")
 

--- a/bigtree/dag/construct.py
+++ b/bigtree/dag/construct.py
@@ -21,8 +21,7 @@ def list_to_dag(
     relations: List[Tuple[str, str]],
     node_type: Type[T] = dagnode.DAGNode,  # type: ignore[assignment]
 ) -> T:
-    """Construct DAG from list of tuples containing parent-child names.
-    Note that node names must be unique.
+    """Construct DAG from list of tuples containing parent-child names. Note that node names must be unique.
 
     Examples:
         >>> from bigtree import list_to_dag, dag_iterator
@@ -32,11 +31,11 @@ def list_to_dag(
         [('a', 'd'), ('c', 'd'), ('d', 'e'), ('a', 'c'), ('b', 'c')]
 
     Args:
-        relations (List[Tuple[str, str]]): list containing tuple of parent-child names
-        node_type (Type[DAGNode]): node type of DAG to be created, defaults to ``DAGNode``
+        relations: list containing tuple of parent-child names
+        node_type: node type of DAG to be created
 
     Returns:
-        (DAGNode)
+        DAG node
     """
     assertions.assert_length_not_empty(relations, "Input list", "relations")
 
@@ -66,8 +65,7 @@ def dict_to_dag(
     node_type: Type[T] = dagnode.DAGNode,  # type: ignore[assignment]
 ) -> T:
     """Construct DAG from nested dictionary, ``key``: child name, ``value``: dictionary of parent names, attribute
-    name, and attribute value.
-    Note that node names must be unique.
+    name, and attribute value. Note that node names must be unique.
 
     Examples:
         >>> from bigtree import dict_to_dag, dag_iterator
@@ -83,13 +81,13 @@ def dict_to_dag(
         [('a', 'd'), ('c', 'd'), ('d', 'e'), ('a', 'c'), ('b', 'c')]
 
     Args:
-        relation_attrs (Dict[str, Any]): dictionary containing node, node parents, and node attribute information,
+        relation_attrs: dictionary containing node, node parents, and node attribute information,
             key: child name, value: dictionary of parent names, node attribute, and attribute value
-        parent_key (str): key of dictionary to retrieve list of parents name, defaults to 'parent'
-        node_type (Type[DAGNode]): node type of DAG to be created, defaults to ``DAGNode``
+        parent_key: key of dictionary to retrieve list of parents name
+        node_type: node type of DAG to be created
 
     Returns:
-        (DAGNode)
+        DAG node
     """
     assertions.assert_length_not_empty(relation_attrs, "Dictionary", "relation_attrs")
 
@@ -133,8 +131,7 @@ def dataframe_to_dag(
     attribute_cols: List[str] = [],
     node_type: Type[T] = dagnode.DAGNode,  # type: ignore[assignment]
 ) -> T:
-    """Construct DAG from pandas DataFrame.
-    Note that node names must be unique.
+    """Construct DAG from pandas DataFrame. Note that node names must be unique.
 
     - `child_col` and `parent_col` specify columns for child name and parent name to construct DAG.
     - `attribute_cols` specify columns for node attribute for child name.
@@ -162,17 +159,15 @@ def dataframe_to_dag(
         [('a', 'd'), ('c', 'd'), ('d', 'e'), ('a', 'c'), ('b', 'c')]
 
     Args:
-        data (pd.DataFrame): data containing path and node attribute information
-        child_col (str): column of data containing child name information, defaults to ''
-            if not set, it will take the first column of data
-        parent_col (str): column of data containing parent name information, defaults to ''
-            if not set, it will take the second column of data
-        attribute_cols (List[str]): columns of data containing child node attribute information,
-            if not set, it will take all columns of data except `child_col` and `parent_col`
-        node_type (Type[DAGNode]): node type of DAG to be created, defaults to ``DAGNode``
+        data: data containing path and node attribute information
+        child_col: column of data containing child name information, if not set, it will take the first column of data
+        parent_col: column of data containing parent name information, if not set, it will take the second column of data
+        attribute_cols: columns of data containing child node attribute information, if not set, it will take all columns
+            of data except `child_col` and `parent_col`
+        node_type: node type of DAG to be created
 
     Returns:
-        (DAGNode)
+        DAG node
     """
     assertions.assert_dataframe_not_empty(data)
 

--- a/bigtree/dag/export.py
+++ b/bigtree/dag/export.py
@@ -28,7 +28,7 @@ T = TypeVar("T", bound=dagnode.DAGNode)
 def dag_to_list(
     dag: T,
 ) -> List[Tuple[str, str]]:
-    """Export DAG to list of tuples containing parent-child names
+    """Export DAG to list of tuples containing parent-child names.
 
     Examples:
         >>> from bigtree import DAGNode, dag_to_list
@@ -41,10 +41,10 @@ def dag_to_list(
         [('a', 'c'), ('a', 'd'), ('b', 'c'), ('c', 'd'), ('d', 'e')]
 
     Args:
-        dag (DAGNode): DAG to be exported
+        dag: DAG to be exported
 
     Returns:
-        (List[Tuple[str, str]])
+        List of tuples containing parent-child names
     """
     relations = []
     for parent_node, child_node in iterators.dag_iterator(dag):
@@ -73,14 +73,14 @@ def dag_to_dict(
         {'a': {'step no.': 1}, 'c': {'parent': ['a', 'b'], 'step no.': 2}, 'd': {'parent': ['a', 'c'], 'step no.': 2}, 'b': {'step no.': 1}, 'e': {'parent': ['d'], 'step no.': 3}}
 
     Args:
-        dag (DAGNode): DAG to be exported
-        parent_key (str): dictionary key for `node.parent.node_name`, defaults to `parents`
-        attr_dict (Dict[str, str]): dictionary mapping node attributes to dictionary key,
-            key: node attributes, value: corresponding dictionary key, optional
-        all_attrs (bool): indicator whether to retrieve all `Node` attributes, defaults to False
+        dag: DAG to be exported
+        parent_key: dictionary key for `node.parent.node_name`
+        attr_dict: dictionary mapping node attributes to dictionary key,
+            key: node attributes, value: corresponding dictionary key
+        all_attrs: indicator whether to retrieve all `Node` attributes
 
     Returns:
-        (Dict[str, Any])
+        Dictionary of node names to their attributes
     """
     dag = dag.copy()
     data_dict = {}
@@ -142,15 +142,15 @@ def dag_to_dataframe(
         6    e      d         3
 
     Args:
-        dag (DAGNode): DAG to be exported
-        name_col (str): column name for `node.node_name`, defaults to 'name'
-        parent_col (str): column name for `node.parent.node_name`, defaults to 'parent'
-        attr_dict (Dict[str, str]): dictionary mapping node attributes to column name,
-            key: node attributes, value: corresponding column in dataframe, optional
-        all_attrs (bool): indicator whether to retrieve all `Node` attributes, defaults to False
+        dag: DAG to be exported
+        name_col: column name for `node.node_name`
+        parent_col: column name for `node.parent.node_name`
+        attr_dict: dictionary mapping node attributes to column name,
+            key: node attributes, value: corresponding column in dataframe
+        all_attrs: indicator whether to retrieve all `Node` attributes
 
     Returns:
-        (pd.DataFrame)
+        pandas DataFrame of DAG information
     """
     dag = dag.copy()
     data_list: List[Dict[str, Any]] = []
@@ -192,9 +192,8 @@ def dag_to_dot(
     node_attr: str = "",
     edge_attr: str = "",
 ) -> pydot.Dot:
-    r"""Export DAG or list of DAGs to image.
-    Note that node names must be unique.
-    Possible node attributes include style, fillcolor, shape.
+    r"""Export DAG or list of DAGs to image. Note that node names must be unique. Possible node attributes include
+    style, fillcolor, or shape.
 
     Examples:
         >>> from bigtree import DAGNode, dag_to_dot
@@ -225,20 +224,19 @@ def dag_to_dot(
         'strict digraph G {\nrankdir=TB;\nc [label=c];\na [label=a];\na -> c;\nd [label=d];\na [label=a];\na -> d;\nc [label=c];\nb [label=b];\nb -> c;\nd [label=d];\nc [label=c];\nc -> d;\ne [label=e];\nd [label=d];\nd -> e;\n}\n'
 
     Args:
-        dag (Union[DAGNode, List[DAGNode]]): DAG or list of DAGs to be exported
-        rankdir (str): set direction of graph layout, defaults to 'TB', can be 'BT, 'LR', 'RL'
-        bg_colour (str): background color of image, defaults to ''
-        node_colour (str): fill colour of nodes, defaults to ''
-        node_shape (str): shape of nodes, defaults to None
-            Possible node_shape include "circle", "square", "diamond", "triangle"
-        edge_colour (str): colour of edges, defaults to ''
-        node_attr (str): node attribute for style, overrides node_colour, defaults to ''
+        dag: DAG or list of DAGs to be exported
+        rankdir: set direction of graph layout, can be 'TB', 'BT, 'LR', or 'RL'
+        bg_colour: background color of image
+        node_colour: fill colour of nodes
+        node_shape: shape of nodes. Possible node_shape include "circle", "square", "diamond", "triangle"
+        edge_colour: colour of edges
+        node_attr: node attribute for style, overrides node_colour.
             Possible node attributes include {"style": "filled", "fillcolor": "gold"}
-        edge_attr (str): edge attribute for style, overrides edge_colour, defaults to ''
+        edge_attr: edge attribute for style, overrides edge_colour.
             Possible edge attributes include {"style": "bold", "label": "edge label", "color": "black"}
 
     Returns:
-        (pydot.Dot)
+        pydot object of DAG
     """
     # Get style
     graph_style = dict(bgcolor=bg_colour) if bg_colour else {}

--- a/bigtree/node/basenode.py
+++ b/bigtree/node/basenode.py
@@ -145,10 +145,10 @@ class BaseNode:
 
     @staticmethod
     def __check_parent_type(new_parent: T) -> None:
-        """Check parent type
+        """Check parent type.
 
         Args:
-            new_parent (Self): parent node
+            new_parent: parent node
         """
         if not (isinstance(new_parent, BaseNode) or new_parent is None):
             raise TypeError(
@@ -156,10 +156,10 @@ class BaseNode:
             )
 
     def __check_parent_loop(self, new_parent: T) -> None:
-        """Check parent type
+        """Check parent type.
 
         Args:
-            new_parent (Self): parent node
+            new_parent: parent node
         """
         if new_parent is not None:
             if new_parent is self:
@@ -177,19 +177,19 @@ class BaseNode:
 
     @property
     def parent(self: T) -> Optional[T]:
-        """Get parent node
+        """Get parent node.
 
         Returns:
-            (Optional[Self])
+            Parent node, none if the node is root
         """
         return self.__parent
 
     @parent.setter
     def parent(self: T, new_parent: T) -> None:
-        """Set parent node
+        """Set parent node.
 
         Args:
-            new_parent (Self): parent node
+            new_parent: parent node
         """
         if ASSERTIONS:
             self.__check_parent_type(new_parent)
@@ -231,26 +231,24 @@ class BaseNode:
             raise exceptions.TreeError(exc_info)
 
     def __pre_assign_parent(self, new_parent: T) -> None:
-        """Custom method to check before attaching parent
-        Can be overridden with `_BaseNode__pre_assign_parent()`
+        """Custom method to check before attaching parent. Can be overridden with `_BaseNode__pre_assign_parent()`.
 
         Args:
-            new_parent (Self): new parent to be added
+            new_parent: new parent to be added
         """
         pass
 
     def __post_assign_parent(self, new_parent: T) -> None:
-        """Custom method to check after attaching parent
-        Can be overridden with `_BaseNode__post_assign_parent()`
+        """Custom method to check after attaching parent. Can be overridden with `_BaseNode__post_assign_parent()`.
 
         Args:
-            new_parent (Self): new parent to be added
+            new_parent: new parent to be added
         """
         pass
 
     @property
     def parents(self) -> None:
-        """Do not allow `parents` attribute to be accessed
+        """Do not allow `parents` attribute to be accessed.
 
         Raises:
             AttributeError: No such attribute
@@ -261,10 +259,10 @@ class BaseNode:
 
     @parents.setter
     def parents(self, new_parent: T) -> None:
-        """Do not allow `parents` attribute to be set
+        """Do not allow `parents` attribute to be set.
 
         Args:
-            new_parent (Self): parent node
+            new_parent: parent node
 
         Raises:
             AttributeError: No such attribute
@@ -273,13 +271,11 @@ class BaseNode:
             "Attempting to set `parents` attribute, do you mean `parent`?"
         )
 
-    def __check_children_type(
-        self: T, new_children: List[T] | Tuple[T] | Set[T]
-    ) -> None:
-        """Check child type
+    def __check_children_type(self: T, new_children: Iterable[T]) -> None:
+        """Check child type.
 
         Args:
-            new_children (Iterable[Self]): child node
+            new_children: child node
         """
         if (
             not isinstance(new_children, list)
@@ -291,10 +287,10 @@ class BaseNode:
             )
 
     def __check_children_loop(self: T, new_children: Iterable[T]) -> None:
-        """Check child loop
+        """Check child loop.
 
         Args:
-            new_children (Iterable[Self]): child node
+            new_children: child node
         """
         seen_children = []
         for new_child in new_children:
@@ -324,19 +320,19 @@ class BaseNode:
 
     @property
     def children(self: T) -> Tuple[T, ...]:
-        """Get child nodes
+        """Get child nodes.
 
         Returns:
-            (Tuple[Self, ...])
+            Child node(s)
         """
         return tuple(self.__children)
 
     @children.setter
     def children(self: T, new_children: List[T] | Tuple[T] | Set[T]) -> None:
-        """Set child nodes
+        """Set child nodes.
 
         Args:
-            new_children (List[Self]): child node
+            new_children: child node
         """
         if ASSERTIONS:
             self.__check_children_type(new_children)
@@ -383,23 +379,21 @@ class BaseNode:
 
     @children.deleter
     def children(self) -> None:
-        """Delete child node(s)"""
+        """Delete child node(s)."""
         for child in self.children:
             child.parent.__children.remove(child)  # type: ignore
             child.__parent = None
 
     def __pre_assign_children(self: T, new_children: Iterable[T]) -> None:
-        """Custom method to check before attaching children
-        Can be overridden with `_BaseNode__pre_assign_children()`
+        """Custom method to check before attaching children. Can be overridden with `_BaseNode__pre_assign_children()`.
 
         Args:
-            new_children (Iterable[Self]): new children to be added
+            new_children: new children to be added
         """
         pass
 
     def __post_assign_children(self: T, new_children: Iterable[T]) -> None:
-        """Custom method to check after attaching children
-        Can be overridden with `_BaseNode__post_assign_children()`
+        """Custom method to check after attaching children. Can be overridden with `_BaseNode__post_assign_children()`.
 
         Args:
             new_children (Iterable[Self]): new children to be added
@@ -408,10 +402,10 @@ class BaseNode:
 
     @property
     def ancestors(self: T) -> Iterable[T]:
-        """Get iterator to yield all ancestors of self, does not include self
+        """Get iterator to yield all ancestors of self, does not include self.
 
         Returns:
-            (Iterable[Self])
+            Ancestor(s) of node excluding itself
         """
         node = self.parent
         while node is not None:
@@ -420,10 +414,10 @@ class BaseNode:
 
     @property
     def descendants(self: T) -> Iterable[T]:
-        """Get iterator to yield all descendants of self, does not include self
+        """Get iterator to yield all descendants of self, does not include self.
 
         Returns:
-            (Iterable[Self])
+            Descendant(s) of node excluding itself
         """
         yield from iterators.preorder_iter(
             self, filter_condition=lambda _node: _node != self
@@ -431,10 +425,10 @@ class BaseNode:
 
     @property
     def leaves(self: T) -> Iterable[T]:
-        """Get iterator to yield all leaf nodes from self
+        """Get iterator to yield all leaf nodes from self.
 
         Returns:
-            (Iterable[Self])
+            Leaf node(s) of node
         """
         yield from iterators.preorder_iter(
             self, filter_condition=lambda _node: _node.is_leaf
@@ -442,21 +436,21 @@ class BaseNode:
 
     @property
     def siblings(self: T) -> Iterable[T]:
-        """Get siblings of self
+        """Get siblings of self.
 
         Returns:
-            (Iterable[Self])
+            Sibling(s) of node
         """
         if self.parent is None:
             return ()
         return tuple(child for child in self.parent.children if child is not self)
 
     @property
-    def left_sibling(self: T) -> T:
-        """Get sibling left of self
+    def left_sibling(self: T) -> Optional[T]:
+        """Get sibling left of self.
 
         Returns:
-            (Self)
+            Left sibling of node
         """
         if self.parent:
             children = self.parent.children
@@ -465,11 +459,11 @@ class BaseNode:
                 return self.parent.children[child_idx - 1]
 
     @property
-    def right_sibling(self: T) -> T:
-        """Get sibling right of self
+    def right_sibling(self: T) -> Optional[T]:
+        """Get sibling right of self.
 
         Returns:
-            (Self)
+            Right sibling of node
         """
         if self.parent:
             children = self.parent.children
@@ -479,39 +473,39 @@ class BaseNode:
 
     @property
     def node_path(self: T) -> Iterable[T]:
-        """Get tuple of nodes starting from root
+        """Get tuple of nodes starting from root.
 
         Returns:
-            (Iterable[Self])
+            Node path from root to itself
         """
         if self.parent is None:
-            return [self]
+            return tuple([self])
         return tuple(list(self.parent.node_path) + [self])
 
     @property
     def is_root(self) -> bool:
-        """Get indicator if self is root node
+        """Get indicator if self is root node.
 
         Returns:
-            (bool)
+            Indicator if node is root node
         """
         return self.parent is None
 
     @property
     def is_leaf(self) -> bool:
-        """Get indicator if self is leaf node
+        """Get indicator if self is leaf node.
 
         Returns:
-            (bool)
+            Indicator if node is leaf node
         """
         return not len(list(self.children))
 
     @property
     def root(self: T) -> T:
-        """Get root node of tree
+        """Get root node of tree.
 
         Returns:
-            (Self)
+            Root node
         """
         if self.parent is None:
             return self
@@ -519,10 +513,10 @@ class BaseNode:
 
     @property
     def diameter(self) -> int:
-        """Get diameter of tree or subtree, the length of longest path between any two nodes
+        """Get diameter of tree or subtree, the length of longest path between any two nodes.
 
         Returns:
-            (int)
+            Diameter of node
         """
         diameter = 0
 
@@ -530,13 +524,13 @@ class BaseNode:
             return diameter
 
         def _recursive_diameter(node: T) -> int:
-            """Recursively iterate through node and its children to get diameter of node
+            """Recursively iterate through node and its children to get diameter of node.
 
             Args:
-                node (Node): current node
+                node: current node
 
             Returns:
-                (int)
+                Diameter of node
             """
             nonlocal diameter
             if node.is_leaf:
@@ -550,10 +544,10 @@ class BaseNode:
 
     @property
     def depth(self) -> int:
-        """Get depth of self, indexing starts from 1
+        """Get depth of self, indexing starts from 1.
 
         Returns:
-            (int)
+            Depth of node
         """
         if self.parent is None:
             return 1
@@ -561,10 +555,10 @@ class BaseNode:
 
     @property
     def max_depth(self) -> int:
-        """Get maximum depth from root to leaf node
+        """Get maximum depth from root to leaf node.
 
         Returns:
-            (int)
+            Maximum depth of tree
         """
         return max(
             [self.root.depth] + [node.depth for node in list(self.root.descendants)]
@@ -572,25 +566,25 @@ class BaseNode:
 
     @classmethod
     def from_dict(cls, input_dict: Dict[str, Any]) -> BaseNode:
-        """Construct node from dictionary, all keys of dictionary will be stored as class attributes
-        Input dictionary must have key `name` if not `Node` will not have any name
+        """Construct node from dictionary, all keys of dictionary will be stored as class attributes.
+        Input dictionary must have key `name` if not `Node` will not have any name.
 
         Examples:
             >>> from bigtree import Node
             >>> a = Node.from_dict({"name": "a", "age": 90})
 
         Args:
-            input_dict (Dict[str, Any]): dictionary with node information, key: attribute name, value: attribute value
+            input_dict: dictionary with node information, key: attribute name, value: attribute value
 
         Returns:
-            (BaseNode)
+            Base node
         """
         return cls(**input_dict)
 
     def describe(
         self, exclude_attributes: List[str] = [], exclude_prefix: str = ""
     ) -> List[Tuple[str, Any]]:
-        """Get node information sorted by attribute name, returns list of tuples
+        """Get node information sorted by attribute name, returns list of tuples.
 
         Examples:
             >>> from bigtree.node.node import Node
@@ -603,11 +597,11 @@ class BaseNode:
             [('age', 90)]
 
         Args:
-            exclude_attributes (List[str]): list of attributes to exclude
-            exclude_prefix (str): prefix of attributes to exclude
+            exclude_attributes: list of attributes to exclude
+            exclude_prefix: prefix of attributes to exclude
 
         Returns:
-            (List[Tuple[str, Any]])
+            List of attribute name and attribute value pairs
         """
         return [
             item
@@ -617,8 +611,7 @@ class BaseNode:
         ]
 
     def get_attr(self, attr_name: str, default_value: Any = None) -> Any:
-        """Get value of node attribute
-        Returns default value if attribute name does not exist
+        """Get value of node attribute. Returns default value if attribute name does not exist.
 
         Examples:
             >>> from bigtree.node.node import Node
@@ -627,11 +620,11 @@ class BaseNode:
             90
 
         Args:
-            attr_name (str): attribute name
-            default_value (Any): default value if attribute does not exist, defaults to None
+            attr_name: attribute name
+            default_value: default value if attribute does not exist
 
         Returns:
-            (Any)
+            Attribute value of node
         """
         try:
             return getattr(self, attr_name)
@@ -639,7 +632,7 @@ class BaseNode:
             return default_value
 
     def set_attrs(self, attrs: Dict[str, Any]) -> None:
-        """Set node attributes
+        """Set node attributes.
 
         Examples:
             >>> from bigtree.node.node import Node
@@ -649,13 +642,12 @@ class BaseNode:
             Node(/a, age=90)
 
         Args:
-            attrs (Dict[str, Any]): attribute dictionary,
-                key: attribute name, value: attribute value
+            attrs.: attribute dictionary, key: attribute name, value: attribute value
         """
         self.__dict__.update(attrs)
 
     def go_to(self: T, node: T) -> Iterable[T]:
-        """Get path from current node to specified node from same tree
+        """Get path from current node to specified node from same tree.
 
         Examples:
             >>> from bigtree import Node, print_tree
@@ -684,10 +676,10 @@ class BaseNode:
             [Node(/a/b/d, ), Node(/a/b, ), Node(/a, ), Node(/a/c, ), Node(/a/c/f, )]
 
         Args:
-            node (Self): node to travel to from current node, inclusive of start and end node
+            node: node to travel to from current node, inclusive of start and end node
 
         Returns:
-            (Iterable[Self])
+            Path from current node to destination node
         """
         if not isinstance(node, BaseNode):
             raise TypeError(
@@ -709,24 +701,24 @@ class BaseNode:
         return self_path[:self_min_index] + node_path[node_min_index:]
 
     def append(self: T, other: T) -> None:
-        """Add other as child of self
+        """Add other as child of self.
 
         Args:
-            other (Self): other node, child to be added
+            other: other node, child to be added
         """
         other.parent = self
 
     def extend(self: T, others: List[T]) -> None:
-        """Add others as children of self
+        """Add others as children of self.
 
         Args:
-            others (Self): other nodes, children to be added
+            others: other nodes, children to be added
         """
         for child in others:
             child.parent = self
 
     def copy(self: T) -> T:
-        """Deep copy self; clone self
+        """Deep copy self; clone self.
 
         Examples:
             >>> from bigtree.node.node import Node
@@ -734,12 +726,12 @@ class BaseNode:
             >>> a_copy = a.copy()
 
         Returns:
-            (Self)
+            Cloned copy of node
         """
         return copy.deepcopy(self)
 
     def sort(self: T, **kwargs: Any) -> None:
-        """Sort children, possible keyword arguments include ``key=lambda node: node.node_name``, ``reverse=True``
+        """Sort children, possible keyword arguments include ``key=lambda node: node.node_name``, ``reverse=True``.
         Accepts kwargs for sort() function.
 
         Examples:
@@ -762,8 +754,7 @@ class BaseNode:
         self.__children = children
 
     def plot(self, *args: Any, **kwargs: Any) -> plt.Figure:
-        """Plot tree in line form.
-        Accepts args and kwargs for matplotlib.pyplot.plot() function.
+        """Plot tree in line form. Accepts args and kwargs for matplotlib.pyplot.plot() function.
 
         Examples:
             >>> import matplotlib.pyplot as plt
@@ -780,7 +771,7 @@ class BaseNode:
         return plot_tree(self, *args, **kwargs)
 
     def __copy__(self: T) -> T:
-        """Shallow copy self
+        """Shallow copy self.
 
         Examples:
             >>> import copy
@@ -789,17 +780,17 @@ class BaseNode:
             >>> a_copy = copy.deepcopy(a)
 
         Returns:
-            (Self)
+            Shallow copy of node
         """
         obj: T = type(self).__new__(self.__class__)
         obj.__dict__.update(self.__dict__)
         return obj
 
     def __repr__(self) -> str:
-        """Print format of BaseNode
+        """Print format of BaseNode.
 
         Returns:
-            (str)
+            Print format of BaseNode
         """
         class_name = self.__class__.__name__
         node_dict = self.describe(exclude_prefix="_")
@@ -807,18 +798,18 @@ class BaseNode:
         return f"{class_name}({node_description})"
 
     def __rshift__(self: T, other: T) -> None:
-        """Set children using >> bitshift operator for self >> children (other)
+        """Set children using >> bitshift operator for self >> children (other).
 
         Args:
-            other (Self): other node, children
+            other: other node, children
         """
         other.parent = self
 
     def __lshift__(self: T, other: T) -> None:
-        """Set parent using << bitshift operator for self << parent (other)
+        """Set parent using << bitshift operator for self << parent (other).
 
         Args:
-            other (Self): other node, parent
+            other: other node, parent
         """
         self.parent = other
 
@@ -826,18 +817,18 @@ class BaseNode:
         """Iterate through child nodes
 
         Returns:
-            (Self): child node
+            Iterable of child node(s)
         """
         yield from self.children  # type: ignore
 
     def __contains__(self, other_node: T) -> bool:
-        """Check if child node exists
+        """Check if child node exists.
 
         Args:
-            other_node (T): child node
+            other_node: child node
 
         Returns:
-            (bool)
+            Indicator if other node is child of current node
         """
         return other_node in self.children
 

--- a/bigtree/node/binarynode.py
+++ b/bigtree/node/binarynode.py
@@ -104,46 +104,46 @@ class BinaryNode(node.Node):
 
     @property
     def left(self: T) -> T:
-        """Get left children
+        """Get left children.
 
         Returns:
-            (Self)
+            Left child
         """
         return self.__children[0]
 
     @left.setter
     def left(self: T, left_child: Optional[T]) -> None:
-        """Set left children
+        """Set left children.
 
         Args:
-            left_child (Optional[Self]): left child
+            left_child: left child
         """
         self.children = [left_child, self.right]  # type: ignore
 
     @property
     def right(self: T) -> T:
-        """Get right children
+        """Get right children.
 
         Returns:
-            (Self)
+            Right child
         """
         return self.__children[1]
 
     @right.setter
     def right(self: T, right_child: Optional[T]) -> None:
-        """Set right children
+        """Set right children.
 
         Args:
-            right_child (Optional[Self]): right child
+            right_child: right child
         """
         self.children = [self.left, right_child]  # type: ignore
 
     @staticmethod
     def __check_parent_type(new_parent: Optional[T]) -> None:
-        """Check parent type
+        """Check parent type.
 
         Args:
-            new_parent (Optional[Self]): parent node
+            new_parent: parent node
         """
         if not (isinstance(new_parent, BinaryNode) or new_parent is None):
             raise TypeError(
@@ -152,19 +152,19 @@ class BinaryNode(node.Node):
 
     @property
     def parent(self: T) -> Optional[T]:
-        """Get parent node
+        """Get parent node.
 
         Returns:
-            (Optional[Self])
+            Parent node, none if the node is root
         """
         return self.__parent
 
     @parent.setter
     def parent(self: T, new_parent: Optional[T]) -> None:
-        """Set parent node
+        """Set parent node.
 
         Args:
-            new_parent (Optional[Self]): parent node
+            new_parent: parent node
         """
         if ASSERTIONS:
             self.__check_parent_type(new_parent)
@@ -215,33 +215,31 @@ class BinaryNode(node.Node):
             raise exceptions.TreeError(exc_info)
 
     def __pre_assign_parent(self: T, new_parent: Optional[T]) -> None:
-        """Custom method to check before attaching parent
-        Can be overridden with `_BinaryNode__pre_assign_parent()`
+        """Custom method to check before attaching parent. Can be overridden with `_BinaryNode__pre_assign_parent()`.
 
         Args:
-            new_parent (Optional[Self]): new parent to be added
+            new_parent: new parent to be added
         """
         pass
 
     def __post_assign_parent(self: T, new_parent: Optional[T]) -> None:
-        """Custom method to check after attaching parent
-        Can be overridden with `_BinaryNode__post_assign_parent()`
+        """Custom method to check after attaching parent. Can be overridden with `_BinaryNode__post_assign_parent()`.
 
         Args:
-            new_parent (Optional[Self]): new parent to be added
+            new_parent: new parent to be added
         """
         pass
 
     def __check_children_type(
         self: T, new_children: List[Optional[T]]
     ) -> List[Optional[T]]:
-        """Check child type
+        """Check child type.
 
         Args:
-            new_children (List[Optional[Self]]): child node
+            new_children: child node
 
         Returns:
-            (List[Optional[Self]])
+            Child nodes, initialise child to None if no new children defined
         """
         if not len(new_children):
             new_children = [None, None]
@@ -250,10 +248,10 @@ class BinaryNode(node.Node):
         return new_children
 
     def __check_children_loop(self: T, new_children: List[Optional[T]]) -> None:
-        """Check child loop
+        """Check child loop.
 
         Args:
-            new_children (List[Optional[Self]]): child node
+            new_children: child node
         """
         seen_children = []
         for new_child in new_children:
@@ -284,19 +282,19 @@ class BinaryNode(node.Node):
 
     @property
     def children(self: T) -> Tuple[T, ...]:
-        """Get child nodes
+        """Get child nodes.
 
         Returns:
-            (Tuple[Optional[Self]])
+            Child nodes
         """
         return tuple(self.__children)
 
     @children.setter
     def children(self: T, _new_children: List[Optional[T]]) -> None:
-        """Set child nodes
+        """Set child nodes.
 
         Args:
-            _new_children (List[Optional[Self]]): child node
+            _new_children: child node
         """
         self._BaseNode__check_children_type(_new_children)  # type: ignore
         new_children = self.__check_children_type(_new_children)
@@ -351,41 +349,39 @@ class BinaryNode(node.Node):
 
     @children.deleter
     def children(self) -> None:
-        """Delete child node(s)"""
+        """Delete child node(s)."""
         for child in self.children:
             if child is not None:
                 child.parent.__children.remove(child)  # type: ignore
                 child.__parent = None
 
     def __pre_assign_children(self: T, new_children: List[Optional[T]]) -> None:
-        """Custom method to check before attaching children
-        Can be overridden with `_BinaryNode__pre_assign_children()`
+        """Custom method to check before attaching children. Can be overridden with `_BinaryNode__pre_assign_children()`.
 
         Args:
-            new_children (List[Optional[Self]]): new children to be added
+            new_children: new children to be added
         """
         pass
 
     def __post_assign_children(self: T, new_children: List[Optional[T]]) -> None:
-        """Custom method to check after attaching children
-        Can be overridden with `_BinaryNode__post_assign_children()`
+        """Custom method to check after attaching children. Can be overridden with `_BinaryNode__post_assign_children()`.
 
         Args:
-            new_children (List[Optional[Self]]): new children to be added
+            new_children: new children to be added
         """
         pass
 
     @property
     def is_leaf(self) -> bool:
-        """Get indicator if self is leaf node
+        """Get indicator if self is leaf node.
 
         Returns:
-            (bool)
+            Indicator if node is leaf node
         """
         return not len([child for child in self.children if child])
 
     def sort(self, **kwargs: Any) -> None:
-        """Sort children, possible keyword arguments include ``key=lambda node: node.val``, ``reverse=True``
+        """Sort children, possible keyword arguments include ``key=lambda node: node.val``, ``reverse=True``.
 
         Examples:
             >>> from bigtree import BinaryNode, print_tree
@@ -408,10 +404,10 @@ class BinaryNode(node.Node):
             self.__children = children  # type: ignore
 
     def __repr__(self) -> str:
-        """Print format of BinaryNode
+        """Print format of BinaryNode.
 
         Returns:
-            (str)
+            Print format of BinaryNode
         """
         class_name = self.__class__.__name__
         node_dict = self.describe(exclude_prefix="_", exclude_attributes=[])

--- a/bigtree/node/dagnode.py
+++ b/bigtree/node/dagnode.py
@@ -126,7 +126,7 @@ class DAGNode:
 
     @property
     def parent(self) -> None:
-        """Do not allow `parent` attribute to be accessed
+        """Do not allow `parent` attribute to be accessed.
 
         Raises:
             AttributeError: No such attribute
@@ -137,10 +137,10 @@ class DAGNode:
 
     @parent.setter
     def parent(self, new_parent: T) -> None:
-        """Do not allow `parent` attribute to be set
+        """Do not allow `parent` attribute to be set.
 
         Args:
-            new_parent (Self): parent node
+            new_parent: parent node
 
         Raises:
             AttributeError
@@ -151,10 +151,10 @@ class DAGNode:
 
     @staticmethod
     def __check_parent_type(new_parents: List[T]) -> None:
-        """Check parent type
+        """Check parent type.
 
         Args:
-            new_parents (List[Self]): parent nodes
+            new_parents: parent nodes
         """
         if not isinstance(new_parents, list):
             raise TypeError(
@@ -162,10 +162,10 @@ class DAGNode:
             )
 
     def __check_parent_loop(self: T, new_parents: List[T]) -> None:
-        """Check parent type
+        """Check parent type.
 
         Args:
-            new_parents (List[Self]): parent nodes
+            new_parents: parent nodes
         """
         seen_parent = []
         for new_parent in new_parents:
@@ -196,19 +196,19 @@ class DAGNode:
 
     @property
     def parents(self: T) -> Iterable[T]:
-        """Get parent nodes
+        """Get parent nodes.
 
         Returns:
-            (Iterable[Self])
+            Parent node(s)
         """
         return tuple(self.__parents)
 
     @parents.setter
     def parents(self: T, new_parents: List[T]) -> None:
-        """Set parent node
+        """Set parent node.
 
         Args:
-            new_parents (List[Self]): parent nodes
+            new_parents: parent nodes
         """
         if ASSERTIONS:
             self.__check_parent_type(new_parents)
@@ -235,28 +235,26 @@ class DAGNode:
             raise exceptions.TreeError(exc_info)
 
     def __pre_assign_parents(self: T, new_parents: List[T]) -> None:
-        """Custom method to check before attaching parent
-        Can be overridden with `_DAGNode__pre_assign_parent()`
+        """Custom method to check before attaching parent. Can be overridden with `_DAGNode__pre_assign_parent()`.
 
         Args:
-            new_parents (List[Self]): new parents to be added
+            new_parents: new parents to be added
         """
         pass
 
     def __post_assign_parents(self: T, new_parents: List[T]) -> None:
-        """Custom method to check after attaching parent
-        Can be overridden with `_DAGNode__post_assign_parent()`
+        """Custom method to check after attaching parent. Can be overridden with `_DAGNode__post_assign_parent()`.
 
         Args:
-            new_parents (List[Self]): new parents to be added
+            new_parents: new parents to be added
         """
         pass
 
     def __check_children_type(self: T, new_children: Iterable[T]) -> None:
-        """Check child type
+        """Check child type.
 
         Args:
-            new_children (Iterable[Self]): child node
+            new_children: child node
         """
         if not isinstance(new_children, Iterable):
             raise TypeError(
@@ -264,10 +262,10 @@ class DAGNode:
             )
 
     def __check_children_loop(self: T, new_children: Iterable[T]) -> None:
-        """Check child loop
+        """Check child loop.
 
         Args:
-            new_children (Iterable[Self]): child node
+            new_children: child node
         """
         seen_children = []
         for new_child in new_children:
@@ -297,19 +295,19 @@ class DAGNode:
 
     @property
     def children(self: T) -> Iterable[T]:
-        """Get child nodes
+        """Get child nodes.
 
         Returns:
-            (Iterable[Self])
+            Child node(s)
         """
         return tuple(self.__children)
 
     @children.setter
     def children(self: T, new_children: Iterable[T]) -> None:
-        """Set child nodes
+        """Set child nodes.
 
         Args:
-            new_children (Iterable[Self]): child node
+            new_children: child node
         """
         if ASSERTIONS:
             self.__check_children_type(new_children)
@@ -336,47 +334,45 @@ class DAGNode:
 
     @children.deleter
     def children(self) -> None:
-        """Delete child node(s)"""
+        """Delete child node(s)."""
         for child in self.children:
             self.__children.remove(child)  # type: ignore
             child.__parents.remove(self)  # type: ignore
 
     def __pre_assign_children(self: T, new_children: Iterable[T]) -> None:
-        """Custom method to check before attaching children
-        Can be overridden with `_DAGNode__pre_assign_children()`
+        """Custom method to check before attaching children. Can be overridden with `_DAGNode__pre_assign_children()`.
 
         Args:
-            new_children (List[Self]): new children to be added
+            new_children: new children to be added
         """
         pass
 
     def __post_assign_children(self: T, new_children: Iterable[T]) -> None:
-        """Custom method to check after attaching children
-        Can be overridden with `_DAGNode__post_assign_children()`
+        """Custom method to check after attaching children. Can be overridden with `_DAGNode__post_assign_children()`.
 
         Args:
-            new_children (List[Self]): new children to be added
+            new_children: new children to be added
         """
         pass
 
     @property
     def ancestors(self: T) -> Iterable[T]:
-        """Get iterator to yield all ancestors of self, does not include self
+        """Get iterator to yield all ancestors of self, does not include self.
 
         Returns:
-            (Iterable[Self])
+            Ancestor(s) of node excluding itself
         """
         if not len(list(self.parents)):
             return ()
 
         def _recursive_parent(node: T) -> Iterable[T]:
-            """Recursively yield parent of current node, returns earliest to latest ancestor
+            """Recursively yield parent of current node, returns earliest to latest ancestor.
 
             Args:
-                node (DAGNode): current node
+                node: current node
 
             Returns:
-                (Iterable[DAGNode])
+                Parent node
             """
             for _node in node.parents:
                 yield from _recursive_parent(_node)
@@ -387,10 +383,10 @@ class DAGNode:
 
     @property
     def descendants(self: T) -> Iterable[T]:
-        """Get iterator to yield all descendants of self, does not include self
+        """Get iterator to yield all descendants of self, does not include self.
 
         Returns:
-            (Iterable[Self])
+            Descendant(s) of node excluding itself
         """
         descendants = iterators.preorder_iter(
             self, filter_condition=lambda _node: _node != self
@@ -399,10 +395,10 @@ class DAGNode:
 
     @property
     def siblings(self: T) -> Iterable[T]:
-        """Get siblings of self
+        """Get siblings of self.
 
         Returns:
-            (Iterable[Self])
+            Sibling(s) of node
         """
         if self.is_root:
             return ()
@@ -415,59 +411,59 @@ class DAGNode:
 
     @property
     def node_name(self) -> str:
-        """Get node name
+        """Get node name.
 
         Returns:
-            (str)
+            Node name
         """
         return self.name
 
     @property
     def is_root(self) -> bool:
-        """Get indicator if self is root node
+        """Get indicator if self is root node.
 
         Returns:
-            (bool)
+            Indicator if node is root node
         """
         return not len(list(self.parents))
 
     @property
     def is_leaf(self) -> bool:
-        """Get indicator if self is leaf node
+        """Get indicator if self is leaf node.
 
         Returns:
-            (bool)
+            Indicator if node is leaf node
         """
         return not len(list(self.children))
 
     @classmethod
     def from_dict(cls, input_dict: Dict[str, Any]) -> DAGNode:
-        """Construct node from dictionary, all keys of dictionary will be stored as class attributes
-        Input dictionary must have key `name` if not `Node` will not have any name
+        """Construct node from dictionary, all keys of dictionary will be stored as class attributes.
+        Input dictionary must have key `name` if not `Node` will not have any name.
 
         Examples:
             >>> from bigtree import DAGNode
             >>> a = DAGNode.from_dict({"name": "a", "age": 90})
 
         Args:
-            input_dict (Dict[str, Any]): dictionary with node information, key: attribute name, value: attribute value
+            input_dict: dictionary with node information, key: attribute name, value: attribute value
 
         Returns:
-            (DAGNode)
+            DAG node
         """
         return cls(**input_dict)
 
     def describe(
         self, exclude_attributes: List[str] = [], exclude_prefix: str = ""
     ) -> List[Tuple[str, Any]]:
-        """Get node information sorted by attribute name, returns list of tuples
+        """Get node information sorted by attribute name, returns list of tuples.
 
         Args:
-            exclude_attributes (List[str]): list of attributes to exclude
-            exclude_prefix (str): prefix of attributes to exclude
+            exclude_attributes: list of attributes to exclude
+            exclude_prefix: prefix of attributes to exclude
 
         Returns:
-            (List[Tuple[str, Any]])
+            List of attribute name and attribute value pairs
         """
         return [
             item
@@ -477,15 +473,14 @@ class DAGNode:
         ]
 
     def get_attr(self, attr_name: str, default_value: Any = None) -> Any:
-        """Get value of node attribute
-        Returns default value if attribute name does not exist
+        """Get value of node attribute. Returns default value if attribute name does not exist.
 
         Args:
-            attr_name (str): attribute name
-            default_value (Any): default value if attribute does not exist, defaults to None
+            attr_name: attribute name
+            default_value: default value if attribute does not exist
 
         Returns:
-            (Any)
+            Attribute value of node
         """
         try:
             return getattr(self, attr_name)
@@ -493,7 +488,7 @@ class DAGNode:
             return default_value
 
     def set_attrs(self, attrs: Dict[str, Any]) -> None:
-        """Set node attributes
+        """Set node attributes.
 
         Examples:
             >>> from bigtree.node.dagnode import DAGNode
@@ -503,13 +498,12 @@ class DAGNode:
             DAGNode(a, age=90)
 
         Args:
-            attrs (Dict[str, Any]): attribute dictionary,
-                key: attribute name, value: attribute value
+            attrs: attribute dictionary, key: attribute name, value: attribute value
         """
         self.__dict__.update(attrs)
 
     def go_to(self: T, node: T) -> List[List[T]]:
-        """Get list of possible paths from current node to specified node from same tree
+        """Get list of possible paths from current node to specified node from same tree.
 
         Examples:
             >>> from bigtree import DAGNode
@@ -531,10 +525,10 @@ class DAGNode:
             bigtree.utils.exceptions.exceptions.TreeError: It is not possible to go to DAGNode(b, )
 
         Args:
-            node (Self): node to travel to from current node, inclusive of start and end node
+            node: node to travel to from current node, inclusive of start and end node
 
         Returns:
-            (List[List[Self]])
+            Path from current node to destination node
         """
         if not isinstance(node, DAGNode):
             raise TypeError(
@@ -548,14 +542,14 @@ class DAGNode:
         self.__path: List[List[T]] = []
 
         def _recursive_path(_node: T, _path: List[T]) -> Optional[List[T]]:
-            """Get path to specified node
+            """Get path to specified node.
 
             Args:
-                _node (DAGNode): current node
-                _path (List[DAGNode]): current path, from start node to current node, excluding current node
+                _node: current node
+                _path: current path, from start node to current node, excluding current node
 
             Returns:
-                (List[DAGNode])
+                Path from current node to destination node
             """
             if _node:  # pragma: no cover
                 _path.append(_node)
@@ -571,7 +565,7 @@ class DAGNode:
         return self.__path
 
     def copy(self: T) -> T:
-        """Deep copy self; clone DAGNode
+        """Deep copy self; clone DAGNode.
 
         Examples:
             >>> from bigtree.node.dagnode import DAGNode
@@ -579,12 +573,12 @@ class DAGNode:
             >>> a_copy = a.copy()
 
         Returns:
-            (Self)
+            Cloned copy of node
         """
         return copy.deepcopy(self)
 
     def __copy__(self: T) -> T:
-        """Shallow copy self
+        """Shallow copy self.
 
         Examples:
             >>> import copy
@@ -593,30 +587,30 @@ class DAGNode:
             >>> a_copy = copy.deepcopy(a)
 
         Returns:
-            (Self)
+            Shallow copy of node
         """
         obj: T = type(self).__new__(self.__class__)
         obj.__dict__.update(self.__dict__)
         return obj
 
     def __getitem__(self, child_name: str) -> "DAGNode":
-        """Get child by name identifier
+        """Get child by name identifier.
 
         Args:
-            child_name (str): name of child node
+            child_name: name of child node
 
         Returns:
-            (Self): child node
+            Child node
         """
         from bigtree.tree.search import find_child_by_name
 
         return find_child_by_name(self, child_name)
 
     def __delitem__(self, child_name: str) -> None:
-        """Delete child by name identifier, will not throw error if child does not exist
+        """Delete child by name identifier, will not throw error if child does not exist.
 
         Args:
-            child_name (str): name of child node
+            child_name: name of child node
         """
         from bigtree.tree.search import find_child_by_name
 
@@ -626,10 +620,10 @@ class DAGNode:
             child.__parents.remove(self)  # type: ignore
 
     def __repr__(self) -> str:
-        """Print format of DAGNode
+        """Print format of DAGNode.
 
         Returns:
-            (str)
+            Print format of DAGNode
         """
         class_name = self.__class__.__name__
         node_dict = self.describe(exclude_attributes=["name"])
@@ -639,37 +633,37 @@ class DAGNode:
         return f"{class_name}({self.node_name}, {node_description})"
 
     def __rshift__(self: T, other: T) -> None:
-        """Set children using >> bitshift operator for self >> children (other)
+        """Set children using >> bitshift operator for self >> children (other).
 
         Args:
-            other (Self): other node, children
+            other: other node, children
         """
         other.parents = [self]
 
     def __lshift__(self: T, other: T) -> None:
-        """Set parent using << bitshift operator for self << parent (other)
+        """Set parent using << bitshift operator for self << parent (other).
 
         Args:
-            other (Self): other node, parent
+            other: other node, parent
         """
         self.parents = [other]
 
     def __iter__(self) -> Generator[T, None, None]:
-        """Iterate through child nodes
+        """Iterate through child nodes.
 
         Returns:
-            (Self): child node
+            Iterable of child node(s)
         """
         yield from self.children  # type: ignore
 
     def __contains__(self, other_node: T) -> bool:
-        """Check if child node exists
+        """Check if child node exists.
 
         Args:
-            other_node (T): child node
+            other_node: child node
 
         Returns:
-            (bool)
+            Indicator if other node is child of current node
         """
         return other_node in self.children
 

--- a/bigtree/node/node.py
+++ b/bigtree/node/node.py
@@ -89,10 +89,10 @@ class Node(basenode.BaseNode):
 
     @property
     def sep(self) -> str:
-        """Get separator, gets from root node
+        """Get separator, gets from root node.
 
         Returns:
-            (str)
+            Seperator
         """
         if self.parent is None:
             return self._sep
@@ -100,28 +100,28 @@ class Node(basenode.BaseNode):
 
     @sep.setter
     def sep(self, value: str) -> None:
-        """Set separator, affects root node
+        """Set separator, affects root node.
 
         Args:
-            value (str): separator to replace default separator
+            value: separator to replace default separator
         """
         self.root._sep = value
 
     @property
     def node_name(self) -> str:
-        """Get node name
+        """Get node name.
 
         Returns:
-            (str)
+            Node name
         """
         return self.name
 
     @property
     def path_name(self) -> str:
-        """Get path name, separated by self.sep
+        """Get path name, separated by self.sep.
 
         Returns:
-            (str)
+            Path name
         """
         ancestors = [self] + list(self.ancestors)
         sep = ancestors[-1].sep
@@ -137,37 +137,34 @@ class Node(basenode.BaseNode):
         pass
 
     def __post_assign_children(self: T, new_children: List[T]) -> None:
-        """Custom method to check after attaching children
-        Can be overridden with `_Node__post_assign_children()`
+        """Custom method to check after attaching children. Can be overridden with `_Node__post_assign_children()`.
 
         Args:
-            new_children (List[Self]): new children to be added
+            new_children: new children to be added
         """
         pass
 
     def __pre_assign_parent(self: T, new_parent: T) -> None:
-        """Custom method to check before attaching parent
-        Can be overridden with `_Node__pre_assign_parent()`
+        """Custom method to check before attaching parent. Can be overridden with `_Node__pre_assign_parent()`.
 
         Args:
-            new_parent (Self): new parent to be added
+            new_parent: new parent to be added
         """
         pass
 
     def __post_assign_parent(self: T, new_parent: T) -> None:
-        """Custom method to check after attaching parent
-        Can be overridden with `_Node__post_assign_parent()`
+        """Custom method to check after attaching parent. Can be overridden with `_Node__post_assign_parent()`.
 
         Args:
-            new_parent (Self): new parent to be added
+            new_parent: new parent to be added
         """
         pass
 
     def _BaseNode__pre_assign_parent(self: T, new_parent: T) -> None:
-        """Do not allow duplicate nodes of same path
+        """Do not allow duplicate nodes of same path.
 
         Args:
-            new_parent (Self): new parent to be added
+            new_parent: new parent to be added
         """
         self.__pre_assign_parent(new_parent)
         if new_parent is not None:
@@ -181,18 +178,18 @@ class Node(basenode.BaseNode):
                 )
 
     def _BaseNode__post_assign_parent(self: T, new_parent: T) -> None:
-        """No rules
+        """No rules.
 
         Args:
-            new_parent (Self): new parent to be added
+            new_parent: new parent to be added
         """
         self.__post_assign_parent(new_parent)
 
     def _BaseNode__pre_assign_children(self: T, new_children: List[T]) -> None:
-        """Do not allow duplicate nodes of same path
+        """Do not allow duplicate nodes of same path.
 
         Args:
-            new_children (List[Self]): new children to be added
+            new_children: new children to be added
         """
         self.__pre_assign_children(new_children)
         children_names = [node.node_name for node in new_children]
@@ -209,49 +206,49 @@ class Node(basenode.BaseNode):
             )
 
     def _BaseNode__post_assign_children(self: T, new_children: List[T]) -> None:
-        """No rules
+        """No rules.
 
         Args:
-            new_children (List[Self]): new children to be added
+            new_children: new children to be added
         """
         self.__post_assign_children(new_children)
 
     def show(self, **kwargs: Any) -> None:
-        """Print tree to console, takes in same keyword arguments as `print_tree` function"""
+        """Print tree to console, takes in same keyword arguments as `print_tree` function."""
         from bigtree.tree.export import print_tree
 
         print_tree(self, **kwargs)
 
     def hshow(self, **kwargs: Any) -> None:
-        """Print tree in horizontal orientation to console, takes in same keyword arguments as `hprint_tree` function"""
+        """Print tree in horizontal orientation to console, takes in same keyword arguments as `hprint_tree` function."""
         from bigtree.tree.export import hprint_tree
 
         hprint_tree(self, **kwargs)
 
     def vshow(self, **kwargs: Any) -> None:
-        """Print tree in vertical orientation to console, takes in same keyword arguments as `vprint_tree` function"""
+        """Print tree in vertical orientation to console, takes in same keyword arguments as `vprint_tree` function."""
         from bigtree.tree.export import vprint_tree
 
         vprint_tree(self, **kwargs)
 
     def __getitem__(self, child_name: str) -> "Node":
-        """Get child by name identifier
+        """Get child by name identifier.
 
         Args:
-            child_name (str): name of child node
+            child_name: name of child node
 
         Returns:
-            (Self): child node
+            Child node
         """
         from bigtree.tree.search import find_child_by_name
 
         return find_child_by_name(self, child_name)
 
     def __delitem__(self, child_name: str) -> None:
-        """Delete child by name identifier, will not throw error if child does not exist
+        """Delete child by name identifier, will not throw error if child does not exist.
 
         Args:
-            child_name (str): name of child node
+            child_name: name of child node
         """
         from bigtree.tree.search import find_child_by_name
 
@@ -260,10 +257,10 @@ class Node(basenode.BaseNode):
             child.parent = None
 
     def __repr__(self) -> str:
-        """Print format of Node
+        """Print format of Node.
 
         Returns:
-            (str)
+            Print format of Node
         """
         class_name = self.__class__.__name__
         node_dict = self.describe(exclude_prefix="_", exclude_attributes=["name"])

--- a/bigtree/tree/construct/dataframes.py
+++ b/bigtree/tree/construct/dataframes.py
@@ -43,8 +43,7 @@ def add_dataframe_to_tree_by_path(
     sep: str = "/",
     duplicate_name_allowed: bool = True,
 ) -> T:
-    """Add nodes and attributes to tree *in-place*, return root of tree.
-    Adds to existing tree from pandas DataFrame.
+    """Add nodes and attributes to tree *in-place*, return root of tree. Adds to existing tree from pandas DataFrame.
 
     Only attributes in `attribute_cols` with non-null values will be added to the tree.
 
@@ -92,17 +91,16 @@ def add_dataframe_to_tree_by_path(
             └── f [age=38]
 
     Args:
-        tree (Node): existing tree
-        data (pd.DataFrame): data containing node path and attribute information
-        path_col (str): column of data containing `path_name` information,
-            if not set, it will take the first column of data
-        attribute_cols (List[str]): columns of data containing node attribute information,
-            if not set, it will take all columns of data except `path_col`
-        sep (str): path separator for input `path_col`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
+        tree: existing tree
+        data: data containing node path and attribute information
+        path_col: column of data containing `path_name` information, if not set, it will take the first column of data
+        attribute_cols: columns of data containing node attribute information, if not set, it will take all columns of
+            data except `path_col`
+        sep: path separator for input `path_col`
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -139,8 +137,7 @@ def add_dataframe_to_tree_by_name(
     name_col: str = "",
     attribute_cols: List[str] = [],
 ) -> T:
-    """Add attributes to existing tree *in-place*.
-    Adds to existing tree from pandas DataFrame.
+    """Add attributes to existing tree *in-place*. Adds to existing tree from pandas DataFrame.
 
     Only attributes in `attribute_cols` with non-null values will be added to the tree.
 
@@ -167,15 +164,14 @@ def add_dataframe_to_tree_by_name(
         └── b [age=65]
 
     Args:
-        tree (Node): existing tree
-        data (pd.DataFrame): data containing node name and attribute information
-        name_col (str): column of data containing `name` information,
-            if not set, it will take the first column of data
-        attribute_cols (List[str]): column(s) of data containing node attribute information,
-            if not set, it will take all columns of data except `path_col`
+        tree: existing tree
+        data: data containing node name and attribute information
+        name_col: column of data containing `name` information, if not set, it will take the first column of data
+        attribute_cols: column(s) of data containing node attribute information, if not set, it will take all columns
+            of data except `path_col`
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -211,8 +207,7 @@ def add_polars_to_tree_by_path(
     sep: str = "/",
     duplicate_name_allowed: bool = True,
 ) -> T:
-    """Add nodes and attributes to tree *in-place*, return root of tree.
-    Adds to existing tree from polars DataFrame.
+    """Add nodes and attributes to tree *in-place*, return root of tree. Adds to existing tree from polars DataFrame.
 
     Only attributes in `attribute_cols` with non-null values will be added to the tree.
 
@@ -260,17 +255,16 @@ def add_polars_to_tree_by_path(
             └── f [age=38]
 
     Args:
-        tree (Node): existing tree
-        data (pl.DataFrame): data containing node path and attribute information
-        path_col (str): column of data containing `path_name` information,
-            if not set, it will take the first column of data
-        attribute_cols (List[str]): columns of data containing node attribute information,
-            if not set, it will take all columns of data except `path_col`
-        sep (str): path separator for input `path_col`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
+        tree: existing tree
+        data: data containing node path and attribute information
+        path_col: column of data containing `path_name` information, if not set, it will take the first column of data
+        attribute_cols: columns of data containing node attribute information, if not set, it will take all
+            columns of data except `path_col`
+        sep: path separator for input `path_col`
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -309,8 +303,7 @@ def add_polars_to_tree_by_name(
     name_col: str = "",
     attribute_cols: List[str] = [],
 ) -> T:
-    """Add attributes to existing tree *in-place*.
-    Adds to existing tree from polars DataFrame.
+    """Add attributes to existing tree *in-place*. Adds to existing tree from polars DataFrame.
 
     Only attributes in `attribute_cols` with non-null values will be added to the tree.
 
@@ -335,15 +328,14 @@ def add_polars_to_tree_by_name(
         └── b [age=65]
 
     Args:
-        tree (Node): existing tree
-        data (pl.DataFrame): data containing node name and attribute information
-        name_col (str): column of data containing `name` information,
-            if not set, it will take the first column of data
-        attribute_cols (List[str]): column(s) of data containing node attribute information,
-            if not set, it will take all columns of data except `path_col`
+        tree: existing tree
+        data: data containing node name and attribute information
+        name_col: column of data containing `name` information, if not set, it will take the first column of data
+        attribute_cols: column(s) of data containing node attribute information, if not set, it will take all columns
+            of data except `path_col`
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -425,17 +417,16 @@ def dataframe_to_tree(
             └── f [age=38]
 
     Args:
-        data (pd.DataFrame): data containing path and node attribute information
-        path_col (str): column of data containing `path_name` information,
-            if not set, it will take the first column of data
-        attribute_cols (List[str]): columns of data containing node attribute information,
-            if not set, it will take all columns of data except `path_col`
-        sep (str): path separator of input `path_col` and created tree, defaults to `/`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        data: data containing path and node attribute information
+        path_col: column of data containing `path_name` information, if not set, it will take the first column of data
+        attribute_cols: columns of data containing node attribute information, if not set, it will take all
+            columns of data except `path_col`
+        sep: path separator of input `path_col` and created tree
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -529,19 +520,17 @@ def dataframe_to_tree_by_relation(
             └── f [age=38]
 
     Args:
-        data (pd.DataFrame): data containing path and node attribute information
-        child_col (str): column of data containing child name information, defaults to None
-            if not set, it will take the first column of data
-        parent_col (str): column of data containing parent name information, defaults to None
-            if not set, it will take the second column of data
-        attribute_cols (List[str]): columns of data containing node attribute information,
-            if not set, it will take all columns of data except `child_col` and `parent_col`
-        allow_duplicates (bool): allow duplicate intermediate nodes such that child node will
-            be tagged to multiple parent nodes, defaults to False
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        data: data containing path and node attribute information
+        child_col: column of data containing child name information, if not set, it will take the first column of data
+        parent_col: column of data containing parent name information, if not set, it will take the second column of data
+        attribute_cols: columns of data containing node attribute information, if not set, it will take all columns of
+            data except `child_col` and `parent_col`
+        allow_duplicates: allow duplicate intermediate nodes such that child node will
+            be tagged to multiple parent nodes
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -572,10 +561,10 @@ def dataframe_to_tree_by_relation(
         """Retrieve node attributes from dictionary, remove parent and child column from dictionary.
 
         Args:
-            _row (Dict[str, Any]): node attributes
+            _row: node attributes
 
         Returns:
-            (Dict[str, Any])
+            Attribute dictionary
         """
         node_attrs = assertions.filter_attributes(
             _row, omit_keys=[child_col, parent_col], omit_null_values=True
@@ -587,7 +576,7 @@ def dataframe_to_tree_by_relation(
         """Recursive add child to tree, given current node.
 
         Args:
-            parent_node (Node): parent node
+            parent_node: parent node
         """
         child_rows = data[data[parent_col] == parent_node.node_name]
 
@@ -661,17 +650,16 @@ def polars_to_tree(
             └── f [age=38]
 
     Args:
-        data (pl.DataFrame): data containing path and node attribute information
-        path_col (str): column of data containing `path_name` information,
-            if not set, it will take the first column of data
-        attribute_cols (List[str]): columns of data containing node attribute information,
-            if not set, it will take all columns of data except `path_col`
-        sep (str): path separator of input `path_col` and created tree, defaults to `/`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        data: data containing path and node attribute information
+        path_col: column of data containing `path_name` information, if not set, it will take the first column of data
+        attribute_cols: columns of data containing node attribute information, if not set, it will take all columns of
+            data except `path_col`
+        sep: path separator of input `path_col` and created tree
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -766,19 +754,17 @@ def polars_to_tree_by_relation(
             └── f [age=38]
 
     Args:
-        data (pl.DataFrame): data containing path and node attribute information
-        child_col (str): column of data containing child name information, defaults to None
-            if not set, it will take the first column of data
-        parent_col (str): column of data containing parent name information, defaults to None
-            if not set, it will take the second column of data
-        attribute_cols (List[str]): columns of data containing node attribute information,
-            if not set, it will take all columns of data except `child_col` and `parent_col`
-        allow_duplicates (bool): allow duplicate intermediate nodes such that child node will
-            be tagged to multiple parent nodes, defaults to False
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        data: data containing path and node attribute information
+        child_col: column of data containing child name information, if not set, it will take the first column of data
+        parent_col: column of data containing parent name information, if not set, it will take the second column of data
+        attribute_cols: columns of data containing node attribute information, if not set, it will take all columns of
+            data except `child_col` and `parent_col`
+        allow_duplicates: allow duplicate intermediate nodes such that child node will
+            be tagged to multiple parent nodes
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_dataframe_not_empty(data)
 
@@ -809,10 +795,10 @@ def polars_to_tree_by_relation(
         """Retrieve node attributes from dictionary, remove parent and child column from dictionary.
 
         Args:
-            _row (Dict[str, Any]): node attributes
+            _row: node attributes
 
         Returns:
-            (Dict[str, Any])
+            Attribute dictionary
         """
         node_attrs = assertions.filter_attributes(
             _row, omit_keys=[child_col, parent_col], omit_null_values=True
@@ -824,7 +810,7 @@ def polars_to_tree_by_relation(
         """Recursive add child to tree, given current node.
 
         Args:
-            parent_node (Node): parent node
+            parent_node: parent node
         """
         child_rows = data.filter(data[parent_col] == parent_node.node_name)
 

--- a/bigtree/tree/construct/dictionaries.py
+++ b/bigtree/tree/construct/dictionaries.py
@@ -22,8 +22,8 @@ def add_dict_to_tree_by_path(
     sep: str = "/",
     duplicate_name_allowed: bool = True,
 ) -> T:
-    """Add nodes and attributes to tree *in-place*, return root of tree.
-    Adds to existing tree from nested dictionary, ``key``: path, ``value``: dict of attribute name and attribute value.
+    """Add nodes and attributes to tree *in-place*, return root of tree. Adds to existing tree from nested dictionary,
+    ``key``: path, ``value``: dict of attribute name and attribute value.
 
     All attributes in `path_attrs` will be added to the tree, including attributes with null values.
 
@@ -65,14 +65,14 @@ def add_dict_to_tree_by_path(
             └── f
 
     Args:
-        tree (Node): existing tree
-        path_attrs (Dict[str, Dict[str, Any]]): dictionary containing node path and attribute information,
+        tree: existing tree
+        path_attrs: dictionary containing node path and attribute information,
             key: node path, value: dict of node attribute name and attribute value
-        sep (str): path separator for input `path_attrs`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
+        sep: path separator for input `path_attrs`
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_length_not_empty(path_attrs, "Dictionary", "path_attrs")
 
@@ -90,8 +90,8 @@ def add_dict_to_tree_by_path(
 
 
 def add_dict_to_tree_by_name(tree: T, name_attrs: Dict[str, Dict[str, Any]]) -> T:
-    """Add attributes to existing tree *in-place*.
-    Adds to existing tree from nested dictionary, ``key``: name, ``value``: dict of attribute name and attribute value.
+    """Add attributes to existing tree *in-place*. Adds to existing tree from nested dictionary, ``key``: name,
+    ``value``: dict of attribute name and attribute value.
 
     All attributes in `name_attrs` will be added to the tree, including attributes with null values.
 
@@ -112,12 +112,12 @@ def add_dict_to_tree_by_name(tree: T, name_attrs: Dict[str, Dict[str, Any]]) -> 
         └── b [age=65]
 
     Args:
-        tree (Node): existing tree
-        name_attrs (Dict[str, Dict[str, Any]]): dictionary containing node name and attribute information,
-            key: node name, value: dict of node attribute name and attribute value
+        tree: existing tree
+        name_attrs: dictionary containing node name and attribute information, key: node name, value: dict of node
+            attribute name and attribute value
 
     Returns:
-        (Node)
+        Node
     """
     from bigtree.tree.search import findall
 
@@ -140,8 +140,8 @@ def dict_to_tree(
     duplicate_name_allowed: bool = True,
     node_type: Type[T] = node.Node,  # type: ignore[assignment]
 ) -> T:
-    """Construct tree from nested dictionary using path,
-    ``key``: path, ``value``: dict of attribute name and attribute value.
+    """Construct tree from nested dictionary using path, ``key``: path, ``value``: dict of attribute name and attribute
+    value.
 
     Path should contain ``Node`` name, separated by `sep`.
 
@@ -181,14 +181,14 @@ def dict_to_tree(
             └── f [age=38]
 
     Args:
-        path_attrs (Dict[str, Any]): dictionary containing path and node attribute information,
+        path_attrs: dictionary containing path and node attribute information,
             key: path, value: dict of tree attribute and attribute value
-        sep (str): path separator of input `path_attrs` and created tree, defaults to `/`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        sep: path separator of input `path_attrs` and created tree
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_length_not_empty(path_attrs, "Dictionary", "path_attrs")
 
@@ -233,8 +233,8 @@ def nested_dict_to_tree(
     """Construct tree from nested recursive dictionary.
 
     - ``key``: `name_key`, `child_key`, or any attributes key.
-    - ``value`` of `name_key` (str): node name.
-    - ``value`` of `child_key` (List[Dict[str, Any]]): list of dict containing `name_key` and `child_key` (recursive).
+    - ``value`` of `name_key`: node name.
+    - ``value`` of `child_key`: list of dict containing `name_key` and `child_key` (recursive).
 
     Examples:
         >>> from bigtree import nested_dict_to_tree
@@ -261,16 +261,16 @@ def nested_dict_to_tree(
                 └── g [age=10]
 
     Args:
-        node_attrs (Dict[str, Any]): dictionary containing node, children, and node attribute information,
+        node_attrs: dictionary containing node, children, and node attribute information,
             key: `name_key` and `child_key`
             value of `name_key` (str): node name
             value of `child_key` (List[Dict[str, Any]]): list of dict containing `name_key` and `child_key` (recursive)
-        name_key (str): key of node name, value is type str
-        child_key (str): key of child list, value is type list
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        name_key: key of node name, value is type str
+        child_key: key of child list, value is type list
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_length_not_empty(node_attrs, "Dictionary", "node_attrs")
 
@@ -280,11 +280,11 @@ def nested_dict_to_tree(
         """Recursively add child to tree, given child attributes and parent node.
 
         Args:
-            child_dict (Dict[str, Any]): child to be added to tree, from dictionary
-            parent_node (Node): parent node to be assigned to child node, defaults to None
+            child_dict: child to be added to tree, from dictionary
+            parent_node: parent node to be assigned to child node
 
         Returns:
-            (Node)
+            Node
         """
         child_dict = child_dict.copy()
         node_name = child_dict.pop(name_key)

--- a/bigtree/tree/construct/lists.py
+++ b/bigtree/tree/construct/lists.py
@@ -58,13 +58,13 @@ def list_to_tree(
             └── f
 
     Args:
-        paths (List[str]): list containing path strings
-        sep (str): path separator for input `paths` and created tree, defaults to `/`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        paths: list containing path strings
+        sep: path separator for input `paths` and created tree
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_length_not_empty(paths, "Path list", "paths")
 
@@ -112,13 +112,12 @@ def list_to_tree_by_relation(
             └── f
 
     Args:
-        relations (List[Tuple[str, str]]): list containing tuple containing parent-child names
-        allow_duplicates (bool): allow duplicate intermediate nodes such that child node will
-            be tagged to multiple parent nodes, defaults to False
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        relations: list containing tuple containing parent-child names
+        allow_duplicates : allow duplicate intermediate nodes such that child node will be tagged to multiple parent nodes
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_length_not_empty(relations, "Path list", "relations")
 

--- a/bigtree/tree/construct/strings.py
+++ b/bigtree/tree/construct/strings.py
@@ -24,8 +24,8 @@ def add_path_to_tree(
     duplicate_name_allowed: bool = True,
     node_attrs: Dict[str, Any] = {},
 ) -> T:
-    """Add nodes and attributes to existing tree *in-place*, return node of path added.
-    Adds to existing tree from list of path strings.
+    """Add nodes and attributes to existing tree *in-place*, return node of path added. Adds to existing tree from list
+    of path strings.
 
     Path should contain ``Node`` name, separated by `sep`.
 
@@ -53,14 +53,14 @@ def add_path_to_tree(
             └── c
 
     Args:
-        tree (Node): existing tree
-        path (str): path to be added to tree
-        sep (str): path separator for input `path`
-        duplicate_name_allowed (bool): indicator if nodes with duplicate ``Node`` name is allowed, defaults to True
-        node_attrs (Dict[str, Any]): attributes to add to node, key: attribute name, value: attribute value, optional
+        tree: existing tree
+        path: path to be added to tree
+        sep: path separator for input `path`
+        duplicate_name_allowed: indicator if nodes with duplicate ``Node`` name is allowed
+        node_attrs: attributes to add to node, key: attribute name, value: attribute value
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_length_not_empty(path, "Path", "path")
 
@@ -122,13 +122,13 @@ def str_to_tree(
             └── f
 
     Args:
-        tree_string (str): String to construct tree
-        tree_prefix_list (List[str]): List of prefix to mark the end of tree branch/stem and start of node name, optional.
-            If not specified, it will infer unicode characters and whitespace as prefix.
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        tree_string: String to construct tree
+        tree_prefix_list: List of prefix to mark the end of tree branch/stem and start of node name, optional. If not
+            specified, it will infer unicode characters and whitespace as prefix
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     tree_string = tree_string.strip("\n")
     assertions.assert_length_not_empty(tree_string, "Tree string", "tree_string")
@@ -219,13 +219,13 @@ def newick_to_tree(
         └── c [age=60, species=human]
 
     Args:
-        tree_string (str): Newick notation to construct tree
-        length_attr (str): attribute name to store node length, optional, defaults to 'length'
-        attr_prefix (str): prefix before all attributes, within square bracket, used to detect attributes, defaults to "&&NHX:"
-        node_type (Type[Node]): node type of tree to be created, defaults to ``Node``
+        tree_string: Newick notation to construct tree
+        length_attr: attribute name to store node length, optional
+        attr_prefix: prefix before all attributes, within square bracket, used to detect attributes
+        node_type: node type of tree to be created
 
     Returns:
-        (Node)
+        Node
     """
     assertions.assert_length_not_empty(tree_string, "Tree string", "tree_string")
 
@@ -251,14 +251,14 @@ def newick_to_tree(
         """Create node at checkpoint.
 
         Args:
-            _new_node (Optional[Node]): existing node (to add length attribute), or nothing (to create a node)
-            _cumulative_string (str): cumulative string, contains either node name or length attribute
-            _unlabelled_node_counter (int): number of unlabelled nodes, updates and returns counter
-            _depth_nodes (Dict[int, List[Node]]): list of nodes at each depth
-            _current_depth (int): depth of current node or node to be created
+            _new_node: existing node (to add length attribute), or nothing (to create a node)
+            _cumulative_string: cumulative string, contains either node name or length attribute
+            _unlabelled_node_counter: number of unlabelled nodes, updates and returns counter
+            _depth_nodes: list of nodes at each depth
+            _current_depth: depth of current node or node to be created
 
         Returns:
-            (Tuple[Node, int])
+            Node and the current depth of node
         """
         if not _new_node:
             if not _cumulative_string:

--- a/bigtree/tree/export/_stdout.py
+++ b/bigtree/tree/export/_stdout.py
@@ -19,10 +19,10 @@ def calculate_stem_pos(length: int) -> int:
     """Calculate stem position based on length
 
     Args:
-        length (int): length of node
+        length: length of node
 
     Returns:
-        (int) Stem position
+        Stem position
     """
     if length % 2:
         return length // 2
@@ -43,17 +43,17 @@ def format_node(
     """Format node to be same width, able to customise whether to add border
 
     Args:
-        _node (Node): node to format
-        alias (str): node attribute to use for node name in tree as alias to `node_name`. Otherwise, it will default to
+        _node: node to format
+        alias: node attribute to use for node name in tree as alias to `node_name`. Otherwise, it will default to
             `node_name` of node.
-        intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
-        style (Union[BaseHPrintStyle, BaseVPrintStyle]): style to format node, used only if border_style is None
-        border_style (BorderStyle): border style to format node
-        min_width (int): minimum width of node display contents
-        add_buffer (bool): whether to add buffer if style is BaseHPrintStyle and border_style is None
+        intermediate_node_name: indicator if intermediate nodes have node names, defaults to True
+        style: style to format node, used only if border_style is None
+        border_style: border style to format node
+        min_width: minimum width of node display contents
+        add_buffer: whether to add buffer if style is BaseHPrintStyle and border_style is None
 
     Returns:
-        (List[str]) node display
+        node display
     """
     if not intermediate_node_name and _node.children:
         if border_style is None:
@@ -141,11 +141,11 @@ def horizontal_join(node_displays: List[List[str]], spacing: int = 0) -> List[st
     """Horizontally join multiple node displays, for displaying tree vertically
 
     Args:
-        node_displays (List[List[str]]): multiple node displays belonging to the same row
-        spacing (int): spacing between node displays
+        node_displays: multiple node displays belonging to the same row
+        spacing: spacing between node displays
 
     Returns:
-        (List[str]) node display of the row
+        node display of the row
     """
     space = " "
     height = max([len(node_display) for node_display in node_displays])
@@ -171,10 +171,10 @@ def vertical_join(node_displays: List[List[str]]) -> List[str]:
     """Vertically join multiple node displays, for displaying tree horizontally
 
     Args:
-        node_displays (List[List[str]]): multiple node displays belonging to the same column
+        node_displays: multiple node displays belonging to the same column
 
     Returns:
-        (List[str]) node display of the row
+        node display of the row
     """
     space = " "
     width = max([len(node_display[0]) for node_display in node_displays])

--- a/bigtree/tree/export/_stdout.py
+++ b/bigtree/tree/export/_stdout.py
@@ -44,16 +44,15 @@ def format_node(
 
     Args:
         _node: node to format
-        alias: node attribute to use for node name in tree as alias to `node_name`. Otherwise, it will default to
-            `node_name` of node.
-        intermediate_node_name: indicator if intermediate nodes have node names, defaults to True
+        alias: node attribute to use for node name in tree as alias to `node_name`
+        intermediate_node_name: indicator if intermediate nodes have node names
         style: style to format node, used only if border_style is None
         border_style: border style to format node
         min_width: minimum width of node display contents
         add_buffer: whether to add buffer if style is BaseHPrintStyle and border_style is None
 
     Returns:
-        node display
+        Node display
     """
     if not intermediate_node_name and _node.children:
         if border_style is None:
@@ -145,7 +144,7 @@ def horizontal_join(node_displays: List[List[str]], spacing: int = 0) -> List[st
         spacing: spacing between node displays
 
     Returns:
-        node display of the row
+        Node display of the row
     """
     space = " "
     height = max([len(node_display) for node_display in node_displays])
@@ -174,7 +173,7 @@ def vertical_join(node_displays: List[List[str]]) -> List[str]:
         node_displays: multiple node displays belonging to the same column
 
     Returns:
-        node display of the row
+        Node display of the row
     """
     space = " "
     width = max([len(node_display[0]) for node_display in node_displays])

--- a/bigtree/tree/export/_yield_tree.py
+++ b/bigtree/tree/export/_yield_tree.py
@@ -1,0 +1,472 @@
+import collections
+from typing import Iterable, List, Optional, Tuple, Type, TypeVar, Union
+
+from bigtree.node import node
+from bigtree.tree.export._stdout import (
+    calculate_stem_pos,
+    format_node,
+    horizontal_join,
+    vertical_join,
+)
+from bigtree.tree.helper import get_subtree
+from bigtree.utils import constants, iterators
+
+T = TypeVar("T", bound=node.Node)
+
+
+def _get_style_class(
+    base_style: Type[constants.BaseStyle],
+    style: Union[
+        str,
+        Iterable[str],
+        constants.BaseStyle,
+    ],
+    param_name: str,
+) -> constants.BaseStyle:
+    """Get style class from style, which can be a string, style_class, or list of input to style_class
+
+    Args:
+        base_style: style class to return
+        style: style of print
+        param_name: parameter name for error message
+
+    Returns:
+        style class
+    """
+    if isinstance(style, str):
+        return base_style.from_style(style)
+    elif isinstance(style, Iterable):
+        n_fields = len(base_style.__dict__["__dataclass_fields__"])
+        if len(list(style)) != n_fields:
+            raise ValueError(
+                f"Please specify the style of {n_fields} icons in `{param_name}`"
+            )
+        return base_style(*style)
+    return style
+
+
+class BaseYieldTree:
+    def __init__(
+        self,
+        tree: T,
+        node_name_or_path: str = "",
+        max_depth: int = 0,
+        style: Union[
+            str,
+            Iterable[str],
+            constants.BasePrintStyle,
+            constants.BaseHPrintStyle,
+            constants.BaseVPrintStyle,
+        ] = "const",
+        border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
+    ):
+        """Initialise yield tree class
+
+        Args:
+            tree: tree to print
+            node_name_or_path: node to print from, becomes the root node
+            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
+            style: style of print, defaults to const
+            border_style: style of border, defaults to None
+        """
+        self._style_class: Type[constants.BaseStyle]
+        tree = get_subtree(tree, node_name_or_path, max_depth)
+
+        # Set style
+        style_class = _get_style_class(self._style_class, style, "style")
+        border_style_class: Optional[constants.BorderStyle] = None
+        if border_style:
+            border_style_class = _get_style_class(
+                constants.BorderStyle, border_style, "border_style"
+            )  # type: ignore
+
+        self.tree = tree
+        self.style_class = style_class
+        self.border_style_class = border_style_class
+        self.space = " "
+
+    def yield_tree(self, strip: bool) -> Union[List[str], Iterable[Tuple[str, str, T]]]:
+        """Yield tree
+
+        Args:
+            strip: whether to strip results,
+
+        Returns:
+            List of tree string to print
+        """
+        raise NotImplementedError
+
+
+class YieldTree(BaseYieldTree):
+    def __init__(
+        self,
+        tree: T,
+        node_name_or_path: str = "",
+        max_depth: int = 0,
+        style: Union[str, Iterable[str], constants.BasePrintStyle] = "const",
+    ):
+        """Initialise yield tree class
+
+        Args:
+            tree: tree to print
+            node_name_or_path: node to print from, becomes the root node of printing, optional
+            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
+            style: style of print, defaults to const
+        """
+        self._style_class = constants.BasePrintStyle
+        super().__init__(tree, node_name_or_path, max_depth, style, None)
+        self.style_class: constants.BasePrintStyle
+
+    def yield_tree(self, strip: bool = True) -> Iterable[Tuple[str, str, T]]:
+        """Yield tree
+
+        Args:
+            strip: whether to strip results, defaults to True
+
+        Returns:
+            Iterable of tree string to print
+        """
+        gap_str = self.space * len(self.style_class.STEM)
+        unclosed_depth = set()
+        initial_depth = self.tree.depth
+        for _node in iterators.preorder_iter(self.tree):
+            pre_str = ""
+            fill_str = ""
+            if not _node.is_root:
+                node_depth = _node.depth - initial_depth
+
+                # Get fill_str (style_branch or style_stem_final)
+                if _node.right_sibling:
+                    unclosed_depth.add(node_depth)
+                    fill_str = self.style_class.BRANCH
+                else:
+                    if node_depth in unclosed_depth:
+                        unclosed_depth.remove(node_depth)
+                    fill_str = self.style_class.STEM_FINAL
+
+                # Get pre_str (style_stem, style_branch, style_stem_final, or gap)
+                pre_str = ""
+                for _depth in range(1, node_depth):
+                    if _depth in unclosed_depth:
+                        pre_str += self.style_class.STEM
+                    else:
+                        pre_str += gap_str
+
+            yield pre_str, fill_str, _node
+
+
+class HYieldTree(BaseYieldTree):
+    def __init__(
+        self,
+        tree: T,
+        alias: str = "node_name",
+        node_name_or_path: str = "",
+        max_depth: int = 0,
+        intermediate_node_name: bool = True,
+        spacing: int = 0,
+        style: Union[str, Iterable[str], constants.BaseHPrintStyle] = "const",
+        border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
+    ):
+        """Initialise yield tree class
+
+        Args:
+            tree: tree to print
+            alias: node attribute to use for node name in tree as alias to `node_name`, if present.
+                Otherwise, it will default to `node_name` of node
+            node_name_or_path: node to print from, becomes the root node of printing
+            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
+            intermediate_node_name: indicator if intermediate nodes have node names, defaults to True
+            spacing: horizontal spacing between node displays
+            style: style of print, defaults to const
+            border_style: style of border, defaults to None
+        """
+        self._style_class = constants.BaseHPrintStyle
+        super().__init__(tree, node_name_or_path, max_depth, style, border_style)
+        self.style_class: constants.BaseHPrintStyle
+
+        padding_depths = collections.defaultdict(int)
+        if intermediate_node_name:
+            for _idx, _children in enumerate(iterators.levelordergroup_iter(tree)):
+                padding_depths[_idx + 1] = max(
+                    [
+                        len(
+                            format_node(
+                                _node,
+                                alias,
+                                intermediate_node_name,
+                                self.style_class,
+                                self.border_style_class,
+                                add_buffer=False,
+                            )[0]
+                        )
+                        for _node in _children
+                    ]
+                )
+        self.padding_depths = padding_depths
+        self.alias = alias
+        self.intermediate_node_name = intermediate_node_name
+        self.spacing = spacing
+
+    def recursive(
+        self, _node: Union[T, node.Node], _cur_depth: int
+    ) -> Tuple[List[str], int]:
+        """Get string for tree horizontally.
+        Recursively iterate the nodes in post-order traversal manner.
+
+        Args:
+            _node: node to get string
+            _cur_depth: current depth of node
+
+        Returns:
+            Intermediate/final result for node, index of branch
+        """
+        if not _node:
+            # For binary node
+            _node = node.Node(" ")
+        node_display_lines = format_node(
+            _node,
+            self.alias,
+            self.intermediate_node_name,
+            self.style_class,
+            self.border_style_class,
+            self.padding_depths[_cur_depth],
+        )
+        node_mid = calculate_stem_pos(len(node_display_lines))
+
+        children = list(_node.children) if any(list(_node.children)) else []
+        if not len(children):
+            return node_display_lines, node_mid
+
+        result_children, result_idx = [], []
+        cumulative_height = 0
+        for idx, child in enumerate(children):
+            result_child, result_branch_idx = self.recursive(child, _cur_depth + 1)
+            result_idx.append(cumulative_height + result_branch_idx)
+            cumulative_height += len(result_child)
+            result_children.append(result_child)
+
+        # Join children column
+        children_display_lines = vertical_join(result_children)
+
+        # Calculate index of first branch, last branch, total length, and midpoint
+        first, last, total = (
+            result_idx[0],
+            result_idx[-1],
+            len(children_display_lines),
+        )
+        mid = (first + last) // 2
+
+        if len(children) == 1:
+            # Special case for one child (need only one branch)
+            line = (
+                self.space * first
+                + self.style_class.BRANCH
+                + self.space * (total - first - 1)
+            )
+            line_prefix = line_suffix = line
+        elif len(children) == 2 and (last - first == 1):
+            # Special case for two children (need split_branch)
+            # Create gap if two children occupy two rows
+            children_display_lines.insert(last, "")
+            last = first + 2
+            mid = (last - first) // 2
+            line_prefix = (
+                self.space * (first + 1) + self.style_class.BRANCH + self.space
+            )
+            line = (
+                self.space * first
+                + self.style_class.FIRST_CHILD
+                + self.style_class.SPLIT_BRANCH
+                + self.style_class.LAST_CHILD
+            )
+            line_suffix = (
+                self.space * first
+                + self.style_class.BRANCH
+                + self.space
+                + self.style_class.BRANCH
+            )
+        else:
+            line_prefix = self.space * (first + 1)
+            line = self.space * first + self.style_class.FIRST_CHILD
+            line_suffix = self.space * first + self.style_class.BRANCH
+            for idx, (bef, aft) in enumerate(zip(result_idx, result_idx[1:])):
+                line_prefix += self.space * (aft - bef)
+                line += (
+                    self.style_class.STEM * (aft - bef - 1)
+                    + self.style_class.SUBSEQUENT_CHILD
+                )
+                line_suffix += self.space * (aft - bef - 1) + self.style_class.BRANCH
+            line = line[:-1] + self.style_class.LAST_CHILD
+            line_suffix = line_suffix[:-1] + self.style_class.BRANCH
+            if mid in result_idx:
+                stem = (
+                    self.style_class.MIDDLE_CHILD
+                    if mid
+                    else self.style_class.FIRST_CHILD
+                )
+            else:
+                stem = self.style_class.SPLIT_BRANCH
+            line_prefix = (
+                line_prefix[:mid]
+                + self.style_class.BRANCH
+                + line_prefix[mid + 1 :]  # noqa
+            )
+            line = line[:mid] + stem + line[mid + 1 :]  # noqa
+        display_buffer = max(0, mid - node_mid)
+        line_buffer = max(0, node_mid - mid)
+        node_display_buffer = [len(node_display_lines[0]) * self.space] * display_buffer
+        child_display_buffer = [
+            len(children_display_lines[0]) * self.space
+        ] * line_buffer
+        result = horizontal_join(
+            [node_display_buffer + node_display_lines]
+            + [list(" " * line_buffer + line_prefix)] * self.spacing
+            + [list(" " * line_buffer + line)]
+            + [list(" " * line_buffer + line_suffix)] * self.spacing
+            + [child_display_buffer + children_display_lines]
+        )
+        return result, mid + line_buffer
+
+    def yield_tree(self, strip: bool = True) -> List[str]:
+        """Yield tree
+
+        Args:
+            strip: whether to strip results, defaults to True
+
+        Returns:
+            List of tree string to print
+        """
+        result_tree, _ = self.recursive(self.tree, 1)
+        if strip:
+            return [result.rstrip() for result in result_tree]
+        return result_tree
+
+
+class VYieldTree(BaseYieldTree):
+    def __init__(
+        self,
+        tree: T,
+        alias: str = "node_name",
+        node_name_or_path: str = "",
+        max_depth: int = 0,
+        intermediate_node_name: bool = True,
+        spacing: int = 2,
+        style: Union[str, Iterable[str], constants.BaseVPrintStyle] = "const",
+        border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
+    ):
+        """Initialise yield tree class
+
+        Args:
+            tree: tree to print
+            alias: node attribute to use for node name in tree as alias to `node_name`, if present.
+                Otherwise, it will default to `node_name` of node
+            node_name_or_path: node to print from, becomes the root node of printing
+            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
+            intermediate_node_name: indicator if intermediate nodes have node names, defaults to True
+            spacing: horizontal spacing between node displays
+            style: style of print, defaults to const
+            border_style: style of border, defaults to const
+        """
+        self._style_class = constants.BaseVPrintStyle
+        super().__init__(tree, node_name_or_path, max_depth, style, border_style)
+        self.style_class: constants.BaseVPrintStyle
+        self.alias = alias
+        self.intermediate_node_name = intermediate_node_name
+        self.spacing = spacing
+
+    def recursive(self, _node: Union[T, node.Node]) -> Tuple[List[str], int]:
+        """Get string for tree vertically.
+        Recursively iterate the nodes in post-order traversal manner.
+
+        Args:
+            _node: node to get string
+
+        Returns:
+            Intermediate/final result for node, index of branch
+        """
+        if not _node:
+            # For binary node
+            _node = node.Node(" ", parent=node.Node(" "))
+        node_display_lines = format_node(
+            _node,
+            self.alias,
+            self.intermediate_node_name,
+            self.style_class,
+            self.border_style_class,
+        )
+        node_width = len(node_display_lines[0])
+        node_mid = calculate_stem_pos(node_width)
+
+        children = list(_node.children) if any(list(_node.children)) else []
+        if not len(children):
+            return node_display_lines, node_mid
+
+        result_children, result_idx = [], []
+        cumulative_width = 0
+        for idx, child in enumerate(children):
+            result_child, result_branch_idx = self.recursive(child)
+            result_idx.append(cumulative_width + result_branch_idx)
+            cumulative_width += len(result_child[0]) + self.spacing
+            result_children.append(result_child)
+
+        # Join children row
+        children_display_lines = horizontal_join(result_children, self.spacing)
+
+        # Calculate index of first branch, last branch, total length, and midpoint
+        first, last, total = (
+            result_idx[0],
+            result_idx[-1],
+            len(children_display_lines[0]),
+        )
+        mid = (first + last) // 2
+
+        if len(children) == 1:
+            # Special case for one child (need only one branch)
+            line = (
+                self.space * first
+                + self.style_class.BRANCH
+                + self.space * (total - first - 1)
+            )
+        else:
+            line = self.space * first + self.style_class.FIRST_CHILD
+            for idx, (bef, aft) in enumerate(zip(result_idx, result_idx[1:])):
+                line += self.style_class.STEM * (aft - bef - 1)
+                line += self.style_class.SUBSEQUENT_CHILD
+            line = line[:-1] + self.style_class.LAST_CHILD
+            line += self.space * (total - result_idx[-1] - 1)
+            stem = (
+                self.style_class.MIDDLE_CHILD
+                if mid in result_idx
+                else self.style_class.SPLIT_BRANCH
+            )
+            line = line[:mid] + stem + line[mid + 1 :]  # noqa
+        display_buffer = max(0, mid - node_mid)
+        line_buffer = max(0, node_mid - mid)
+        result = vertical_join(
+            [
+                [
+                    display_buffer * self.space + result_line
+                    for result_line in node_display_lines
+                ],
+                [line_buffer * self.space + line],
+                [
+                    line_buffer * self.space + result_line
+                    for result_line in children_display_lines
+                ],
+            ]
+        )
+        return result, mid + line_buffer
+
+    def yield_tree(self, strip: bool = False) -> List[str]:
+        """Yield tree
+
+        Args:
+            strip: whether to strip results, defaults to False
+
+        Returns:
+            List of tree string to print
+        """
+        result_tree, _ = self.recursive(self.tree)
+        if strip:
+            return [result.rstrip() for result in result_tree]
+        return result_tree

--- a/bigtree/tree/export/_yield_tree.py
+++ b/bigtree/tree/export/_yield_tree.py
@@ -28,7 +28,7 @@ def _get_style_class(
     style: Union[str, Iterable[str], TStyle],
     param_name: str,
 ) -> TStyle:
-    """Get style class from style, which can be a string, style_class, or list of input to style_class
+    """Get style class from style, which can be a string, style_class, or list of input to style_class.
 
     Args:
         base_style: style class to return
@@ -36,7 +36,7 @@ def _get_style_class(
         param_name: parameter name for error message
 
     Returns:
-        style class
+        Style class
     """
     if isinstance(style, str):
         return base_style.from_style(style)  # type: ignore
@@ -65,7 +65,7 @@ class BaseYieldTree:
         ] = "const",
         border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
     ):
-        """Initialise yield tree class
+        """Initialise yield tree class.
 
         Args:
             tree: tree to print
@@ -91,10 +91,10 @@ class BaseYieldTree:
         self.space = " "
 
     def yield_tree(self, strip: bool) -> Union[List[str], Iterable[Tuple[str, str, T]]]:
-        """Yield tree
+        """Yield tree.
 
         Args:
-            strip: whether to strip results,
+            strip: whether to strip results
 
         Returns:
             List of tree string to print
@@ -110,23 +110,23 @@ class YieldTree(BaseYieldTree):
         max_depth: int = 0,
         style: Union[str, Iterable[str], constants.BasePrintStyle] = "const",
     ):
-        """Initialise yield tree class
+        """Initialise yield tree class.
 
         Args:
             tree: tree to print
-            node_name_or_path: node to print from, becomes the root node of printing, optional
-            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
-            style: style of print, defaults to const
+            node_name_or_path: node to print from, becomes the root node of printing
+            max_depth: maximum depth of tree to print, based on `depth` attribute
+            style: style of print
         """
         self._style_class = constants.BasePrintStyle
         super().__init__(tree, node_name_or_path, max_depth, style, None)
         self.style_class: constants.BasePrintStyle
 
     def yield_tree(self, strip: bool = True) -> Iterable[Tuple[str, str, T]]:
-        """Yield tree
+        """Yield tree.
 
         Args:
-            strip: whether to strip results, defaults to True
+            strip: whether to strip results
 
         Returns:
             Iterable of tree string to print
@@ -175,18 +175,17 @@ class HYieldTree(BaseYieldTree):
         style: Union[str, Iterable[str], constants.BaseHPrintStyle] = "const",
         border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
     ):
-        """Initialise yield tree class
+        """Initialise yield tree class, yields tree in horizontal fashion.
 
         Args:
             tree: tree to print
-            alias: node attribute to use for node name in tree as alias to `node_name`, if present.
-                Otherwise, it will default to `node_name` of node
+            alias: node attribute to use for node name in tree as alias to `node_name`
             node_name_or_path: node to print from, becomes the root node of printing
-            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
-            intermediate_node_name: indicator if intermediate nodes have node names, defaults to True
+            max_depth: maximum depth of tree to print, based on `depth` attribute
+            intermediate_node_name: indicator if intermediate nodes have node names
             spacing: horizontal spacing between node displays
-            style: style of print, defaults to const
-            border_style: style of border, defaults to None
+            style: style of print
+            border_style: style of border
         """
         self._style_class = constants.BaseHPrintStyle
         super().__init__(tree, node_name_or_path, max_depth, style, border_style)
@@ -218,8 +217,7 @@ class HYieldTree(BaseYieldTree):
     def recursive(
         self, _node: Union[T, node.Node], _cur_depth: int
     ) -> Tuple[List[str], int]:
-        """Get string for tree horizontally.
-        Recursively iterate the nodes in post-order traversal manner.
+        """Get string for tree horizontally. Recursively iterate the nodes in post-order traversal manner.
 
         Args:
             _node: node to get string
@@ -321,10 +319,10 @@ class HYieldTree(BaseYieldTree):
         return result, mid + line_buffer
 
     def yield_tree(self, strip: bool = True) -> List[str]:
-        """Yield tree
+        """Yield tree.
 
         Args:
-            strip: whether to strip results, defaults to True
+            strip: whether to strip results
 
         Returns:
             List of tree string to print
@@ -347,18 +345,17 @@ class VYieldTree(BaseYieldTree):
         style: Union[str, Iterable[str], constants.BaseVPrintStyle] = "const",
         border_style: Optional[Union[str, Iterable[str], constants.BorderStyle]] = None,
     ):
-        """Initialise yield tree class
+        """Initialise yield tree class, yields tree in vertical fashion.
 
         Args:
             tree: tree to print
-            alias: node attribute to use for node name in tree as alias to `node_name`, if present.
-                Otherwise, it will default to `node_name` of node
+            alias: node attribute to use for node name in tree as alias to `node_name`
             node_name_or_path: node to print from, becomes the root node of printing
-            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
-            intermediate_node_name: indicator if intermediate nodes have node names, defaults to True
+            max_depth: maximum depth of tree to print, based on `depth` attribute
+            intermediate_node_name: indicator if intermediate nodes have node names
             spacing: horizontal spacing between node displays
-            style: style of print, defaults to const
-            border_style: style of border, defaults to const
+            style: style of print
+            border_style: style of border
         """
         self._style_class = constants.BaseVPrintStyle
         super().__init__(tree, node_name_or_path, max_depth, style, border_style)
@@ -368,8 +365,7 @@ class VYieldTree(BaseYieldTree):
         self.spacing = spacing
 
     def recursive(self, _node: Union[T, node.Node]) -> Tuple[List[str], int]:
-        """Get string for tree vertically.
-        Recursively iterate the nodes in post-order traversal manner.
+        """Get string for tree vertically. Recursively iterate the nodes in post-order traversal manner.
 
         Args:
             _node: node to get string
@@ -450,10 +446,10 @@ class VYieldTree(BaseYieldTree):
         return result, mid + line_buffer
 
     def yield_tree(self, strip: bool = False) -> List[str]:
-        """Yield tree
+        """Yield tree.
 
         Args:
-            strip: whether to strip results, defaults to False
+            strip: whether to strip results
 
         Returns:
             List of tree string to print

--- a/bigtree/tree/export/_yield_tree.py
+++ b/bigtree/tree/export/_yield_tree.py
@@ -99,7 +99,7 @@ class BaseYieldTree:
         Returns:
             List of tree string to print
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class YieldTree(BaseYieldTree):

--- a/bigtree/tree/export/_yield_tree.py
+++ b/bigtree/tree/export/_yield_tree.py
@@ -70,9 +70,9 @@ class BaseYieldTree:
         Args:
             tree: tree to print
             node_name_or_path: node to print from, becomes the root node
-            max_depth: maximum depth of tree to print, based on `depth` attribute, optional
-            style: style of print, defaults to const
-            border_style: style of border, defaults to None
+            max_depth: maximum depth of tree to print, based on `depth` attribute
+            style: style of print
+            border_style: style of border
         """
         self._style_class: Type[constants.BaseStyle]
         tree = get_subtree(tree, node_name_or_path, max_depth)

--- a/bigtree/tree/export/dataframes.py
+++ b/bigtree/tree/export/dataframes.py
@@ -68,19 +68,19 @@ def tree_to_dataframe(
         2  /a/b/e    e      b          35
 
     Args:
-        tree (Node): tree to be exported
-        path_col (str): column name for `node.path_name`, defaults to 'path'
-        name_col (str): column name for `node.node_name`, defaults to 'name'
-        parent_col (str): column name for `node.parent.node_name`, optional
-        attr_dict (Dict[str, str]): dictionary mapping node attributes to column name,
-            key: node attributes, value: corresponding column in dataframe, optional
-        all_attrs (bool): indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`, defaults to False
-        max_depth (int): maximum depth to export tree, optional
-        skip_depth (int): number of initial depths to skip, optional
-        leaf_only (bool): indicator to retrieve only information from leaf nodes
+        tree: tree to be exported
+        path_col: column name for `node.path_name`
+        name_col: column name for `node.node_name`
+        parent_col: column name for `node.parent.node_name`
+        attr_dict: dictionary mapping node attributes to column name, key: node attributes, value: corresponding column
+            in dataframe
+        all_attrs: indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`
+        max_depth: maximum depth to export tree
+        skip_depth: number of initial depths to skip
+        leaf_only: indicator to retrieve only information from leaf nodes
 
     Returns:
-        (pd.DataFrame)
+        pandas DataFrame containing tree information
     """
     tree = tree.copy()
     data_list = []
@@ -175,19 +175,19 @@ def tree_to_polars(
         └────────┴──────┴────────┴────────────┘
 
     Args:
-        tree (Node): tree to be exported
-        path_col (str): column name for `node.path_name`, defaults to 'path'
-        name_col (str): column name for `node.node_name`, defaults to 'name'
-        parent_col (str): column name for `node.parent.node_name`, optional
-        attr_dict (Dict[str, str]): dictionary mapping node attributes to column name,
-            key: node attributes, value: corresponding column in dataframe, optional
-        all_attrs (bool): indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`, defaults to False
-        max_depth (int): maximum depth to export tree, optional
-        skip_depth (int): number of initial depths to skip, optional
-        leaf_only (bool): indicator to retrieve only information from leaf nodes
+        tree: tree to be exported
+        path_col: column name for `node.path_name`
+        name_col: column name for `node.node_name`
+        parent_col: column name for `node.parent.node_name`
+        attr_dict: dictionary mapping node attributes to column name, key: node attributes, value: corresponding column
+            in dataframe
+        all_attrs: indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`
+        max_depth: maximum depth to export tree
+        skip_depth: number of initial depths to skip
+        leaf_only: indicator to retrieve only information from leaf nodes
 
     Returns:
-        (pl.DataFrame)
+        polars DataFrame containing tree information
     """
     tree = tree.copy()
     data_list = []

--- a/bigtree/tree/export/dictionaries.py
+++ b/bigtree/tree/export/dictionaries.py
@@ -44,18 +44,18 @@ def tree_to_dict(
         {'/a/c': {'name': 'c', 'parent': 'a', 'person age': 60}}
 
     Args:
-        tree (Node): tree to be exported
-        name_key (str): dictionary key for `node.node_name`, defaults to 'name'
-        parent_key (str): dictionary key for `node.parent.node_name`, optional
-        attr_dict (Dict[str, str]): dictionary mapping node attributes to dictionary key,
-            key: node attributes, value: corresponding dictionary key, optional
-        all_attrs (bool): indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`, defaults to False
-        max_depth (int): maximum depth to export tree, optional
-        skip_depth (int): number of initial depths to skip, optional
-        leaf_only (bool): indicator to retrieve only information from leaf nodes
+        tree: tree to be exported
+        name_key: dictionary key for `node.node_name`
+        parent_key: dictionary key for `node.parent.node_name`
+        attr_dict: dictionary mapping node attributes to dictionary key, key: node attributes, value: corresponding
+            dictionary key
+        all_attrs: indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`
+        max_depth: maximum depth to export tree
+        skip_depth: number of initial depths to skip
+        leaf_only: indicator to retrieve only information from leaf nodes
 
     Returns:
-        (Dict[str, Any])
+        Dictionary containing tree information
     """
     tree = tree.copy()
     data_dict = {}
@@ -64,7 +64,7 @@ def tree_to_dict(
         """Recursively iterate through node and its children to export to dictionary.
 
         Args:
-            node (Node): current node
+            node: current node
         """
         if node:
             if (
@@ -124,16 +124,16 @@ def tree_to_nested_dict(
         {'name': 'a', 'age': 90, 'children': [{'name': 'b', 'age': 65, 'children': [{'name': 'd', 'age': 40}, {'name': 'e', 'age': 35}]}, {'name': 'c', 'age': 60}]}
 
     Args:
-        tree (Node): tree to be exported
-        name_key (str): dictionary key for `node.node_name`, defaults to 'name'
-        child_key (str): dictionary key for list of children, optional
-        attr_dict (Dict[str, str]): dictionary mapping node attributes to dictionary key,
-            key: node attributes, value: corresponding dictionary key, optional
-        all_attrs (bool): indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`, defaults to False
-        max_depth (int): maximum depth to export tree, optional
+        tree: tree to be exported
+        name_key: dictionary key for `node.node_name`
+        child_key: dictionary key for list of children
+        attr_dict: dictionary mapping node attributes to dictionary key, key: node attributes, value: corresponding
+            dictionary key
+        all_attrs: indicator whether to retrieve all ``Node`` attributes, overrides `attr_dict`
+        max_depth: maximum depth to export tree
 
     Returns:
-        (Dict[str, Any])
+        Dictionary containing tree information
     """
     tree = tree.copy()
     data_dict: Dict[str, List[Dict[str, Any]]] = {}
@@ -142,8 +142,8 @@ def tree_to_nested_dict(
         """Recursively iterate through node and its children to export to nested dictionary.
 
         Args:
-            node (Node): current node
-            parent_dict (Dict[str, Any]): parent dictionary
+            node: current node
+            parent_dict: parent dictionary
         """
         if node:
             if not max_depth or node.depth <= max_depth:

--- a/bigtree/tree/export/images.py
+++ b/bigtree/tree/export/images.py
@@ -138,26 +138,23 @@ def tree_to_dot(
         ![Export to dot (callable)](https://github.com/kayjan/bigtree/raw/master/assets/export_tree_dot_callable.png)
 
     Args:
-        tree (Node/List[Node]): tree or list of trees to be exported
-        directed (bool): indicator whether graph should be directed or undirected, defaults to True
-        rankdir (str): layout direction, defaults to 'TB' (top to bottom), can be 'BT' (bottom to top),
-            'LR' (left to right), 'RL' (right to left)
-        bg_colour (str): background color of image, defaults to None
-        node_colour (str): fill colour of nodes, defaults to None
-        node_shape (str): shape of nodes, defaults to None
-            Possible node_shape include "circle", "square", "diamond", "triangle"
-        edge_colour (str): colour of edges, defaults to None
-        node_attr (str | Callable): If string type, it refers to ``Node`` attribute for node style.
-            If callable type, it takes in the node itself and returns the node style.
-            This overrides `node_colour` and `node_shape` and defaults to None.
+        tree: tree or list of trees to be exported
+        directed: indicator whether graph should be directed or undirected
+        rankdir: layout direction, accepts 'TB' (top to bottom), 'BT' (bottom to top), 'LR' (left to
+            right), or 'RL' (right to left)
+        bg_colour: background color of image
+        node_colour: fill colour of nodes
+        node_shape: shape of nodes. Possible node_shape include "circle", "square", "diamond", "triangle"
+        edge_colour: colour of edges
+        node_attr: If string type, it refers to ``Node`` attribute for node style. If callable type, it takes
+            in the node itself and returns the node style. This overrides `node_colour` and `node_shape`.
             Possible node styles include {"style": "filled", "fillcolor": "gold", "shape": "diamond"}
-        edge_attr (str | Callable): If stirng type, it refers to ``Node`` attribute for edge style.
-            If callable type, it takes in the node itself and returns the edge style.
-            This overrides `edge_colour`, and defaults to None.
-            Possible edge styles include {"style": "bold", "label": "edge label", "color": "black"}
+        edge_attr: If string type, it refers to ``Node`` attribute for edge style. If callable type, it takes
+            in the node itself and returns the edge style. This overrides `edge_colour`. Possible edge styles
+            include {"style": "bold", "label": "edge label", "color": "black"}
 
     Returns:
-        (pydot.Dot)
+        Dot object of tree
     """
     # Get style
     graph_style = dict(bgcolor=bg_colour) if bg_colour else {}
@@ -184,8 +181,8 @@ def tree_to_dot(
             """Recursively iterate through node and its children to export to dot by creating node and edges.
 
             Args:
-                parent_name (Optional[str]): parent name
-                child_node (Node): current node
+                parent_name: parent name
+                child_node: current node
             """
             _node_style = node_style.copy()
             _edge_style = edge_style.copy()
@@ -255,10 +252,9 @@ def tree_to_pillow_graph(
     rect_width: int = 1,
     **kwargs: Any,
 ) -> Image.Image:
-    r"""Export tree to PIL.Image.Image object. Object can be
-    converted to other formats, such as jpg, or png. Image will look
-    like a tree/graph-like structure, accepts additional keyword arguments
-    as input to `yield_tree`.
+    r"""Export tree to PIL.Image.Image object. Object can be converted to other
+    formats, such as jpg, or png. Image will look like a tree/graph-like structure,
+    accepts additional keyword arguments as input to `yield_tree`.
 
     Customisations:
 
@@ -283,25 +279,25 @@ def tree_to_pillow_graph(
         ![Export to Pillow Graph](https://github.com/kayjan/bigtree/raw/master/assets/tree_pillow_graph.png)
 
     Args:
-        tree (Node): tree to be exported
-        node_content (str): display text in node
-        margin (Dict[str, int]): margin of diagram
-        height_buffer (Union[int, float]): height buffer between node layers, in pixels
-        width_buffer (Union[int, float]) : width buffer between sibling nodes, in pixels
-        font_family (str): file path of font family, requires .ttf file, defaults to DejaVuSans
-        font_size (int): font size, defaults to 12
-        font_colour (Union[Tuple[int, int, int], str]): font colour, accepts tuple of RGB values or string, defaults to black
-        text_align (str): text align for multi-line text
-        bg_colour (Union[Tuple[int, int, int], str]): background of image, accepts tuple of RGB values or string, defaults to white
-        rect_margin (Dict[str, int]): (for rectangle) margin of text to rectangle, in pixels
-        rect_fill (Union[Tuple[int, int, int], str, mpl.colormap]): (for rectangle) colour to use for fill
-        rect_cmap_attr (str): (for rectangle) if rect_fill is a colormap, attribute of node to retrieve fill from colormap,
+        tree: tree to be exported
+        node_content: display text in node
+        margin: margin of diagram
+        height_buffer: height buffer between node layers, in pixels
+        width_buffer: width buffer between sibling nodes, in pixels
+        font_family: file path of font family, requires .ttf file, defaults to DejaVuSans
+        font_size: font size
+        font_colour: font colour, accepts tuple of RGB values or string
+        text_align: text align for multi-line text
+        bg_colour: background of image, accepts tuple of RGB values or string
+        rect_margin: (for rectangle) margin of text to rectangle, in pixels
+        rect_fill: (for rectangle) colour to use for fill
+        rect_cmap_attr: (for rectangle) if rect_fill is a colormap, attribute of node to retrieve fill from colormap,
             must be a float/int attribute
-        rect_outline (Union[Tuple[int, int, int], str]): (for rectangle) colour to use for outline
-        rect_width (int): (for rectangle) line width, in pixels
+        rect_outline: (for rectangle) colour to use for outline
+        rect_width: (for rectangle) line width, in pixels
 
     Returns:
-        (PIL.Image.Image)
+        Pillow object of tree, in graph format
     """
     use_cmap = isinstance(rect_fill, mpl.colors.Colormap)
     if use_cmap and rect_cmap_attr is None:
@@ -444,10 +440,9 @@ def tree_to_pillow(
     bg_colour: Union[Tuple[int, int, int], str] = "white",
     **kwargs: Any,
 ) -> Image.Image:
-    """Export tree to PIL.Image.Image object. Object can be
-    converted to other formats, such as jpg, or png. Image will be
-    similar format as `print_tree`, accepts additional keyword arguments
-    as input to `yield_tree`.
+    """Export tree to PIL.Image.Image object. Object can be converted to other
+    formats, such as jpg, or png. Image will be similar format as `print_tree`,
+    accepts additional keyword arguments as input to `yield_tree`.
 
     Examples:
         >>> from bigtree import Node, tree_to_pillow
@@ -466,17 +461,17 @@ def tree_to_pillow(
         ![Export to pillow](https://github.com/kayjan/bigtree/raw/master/assets/tree_pillow.png)
 
     Args:
-        tree (Node): tree to be exported
-        width (int): width of image, optional as width of image is calculated automatically
-        height (int): height of image, optional as height of image is calculated automatically
-        start_pos (Tuple[int, int]): start position of text, (x-offset, y-offset), defaults to (10, 10)
-        font_family (str): file path of font family, requires .ttf file, defaults to DejaVuSans
-        font_size (int): font size, defaults to 12
-        font_colour (Union[Tuple[int, int, int], str]): font colour, accepts tuple of RGB values or string, defaults to black
-        bg_colour (Union[Tuple[int, int, int], str]): background of image, accepts tuple of RGB values or string, defaults to white
+        tree: tree to be exported
+        width: width of image, optional as width of image is calculated automatically
+        height: height of image, optional as height of image is calculated automatically
+        start_pos: start position of text, (x-offset, y-offset)
+        font_family: file path of font family, requires .ttf file, defaults to DejaVuSans
+        font_size: font size
+        font_colour: font colour, accepts tuple of RGB values or string
+        bg_colour: background of image, accepts tuple of RGB values or string
 
     Returns:
-        (PIL.Image.Image)
+        Pillow object of tree, in condensed text format
     """
     # Initialize font
     font = _load_font(font_family, font_size)
@@ -493,10 +488,10 @@ def tree_to_pillow(
         """Get list dimensions.
 
         Args:
-            text_list (List[str]): list of texts
+            text_list: list of texts
 
         Returns:
-            (List[Tuple[int, int, int, int]]): list of (left, top, right, bottom) bounding box
+            Bounding box dimensions (left, top, right, bottom)
         """
         _image = Image.new("RGB", (0, 0))
         _draw = ImageDraw.Draw(_image)
@@ -670,30 +665,27 @@ def tree_to_mermaid(
         ```
 
     Args:
-        tree (Node): tree to be exported
-        title (str): title, defaults to None
-        theme (str): theme or colour scheme, defaults to None
-        rankdir (str): layout direction, defaults to 'TB' (top to bottom), can be 'BT' (bottom to top),
-            'LR' (left to right), 'RL' (right to left)
-        line_shape (str): line shape or curvature, defaults to 'basis'
-        node_colour (str): fill colour of nodes, can be colour name or hexcode, defaults to None
-        node_border_colour (str): border colour of nodes, can be colour name or hexcode, defaults to None
-        node_border_width (float): width of node border, defaults to 1
-        node_shape (str): node shape, sets the shape of every node, defaults to 'rounded_edge'
-        node_shape_attr (str | Callable): If string type, it refers to ``Node`` attribute for node shape.
-            If callable type, it takes in the node itself and returns the node shape.
-            This sets the shape of custom nodes, and overrides default `node_shape`, defaults to None
-        edge_arrow (str): edge arrow style from parent to itself, sets the arrow style of every edge, defaults to 'normal'
-        edge_arrow_attr (str | Callable): If string type, it refers to ``Node`` attribute for edge arrow style.
-            If callable type, it takes in the node itself and returns the edge arrow style.
-            This sets the edge arrow style of custom nodes from parent to itself, and overrides default `edge_arrow`, defaults to None
-        edge_label (str): ``Node`` attribute for edge label from parent to itself, defaults to None
-        node_attr (str | Callable): If string type, it refers to ``Node`` attribute for node style.
-            If callable type, it takes in the node itself and returns the node style.
-            This overrides `node_colour`, `node_border_colour`, and `node_border_width`, defaults to None
+        tree: tree to be exported
+        title: title
+        theme: theme or colour scheme
+        rankdir: layout direction, accepts 'TB' (top to bottom), 'BT' (bottom to top), 'LR' (left to right), 'RL' (right to left)
+        line_shape: line shape or curvature
+        node_colour: fill colour of nodes, can be colour name or hexcode
+        node_border_colour: border colour of nodes, can be colour name or hexcode
+        node_border_width: width of node border
+        node_shape: node shape, sets the shape of every node
+        node_shape_attr: If string type, it refers to ``Node`` attribute for node shape. If callable type, it takes in the node itself
+            and returns the node shape. This sets the shape of custom nodes, and overrides default `node_shape`
+        edge_arrow: edge arrow style from parent to itself, sets the arrow style of every edge
+        edge_arrow_attr: If string type, it refers to ``Node`` attribute for edge arrow style. If callable type, it takes in the node
+            itself and returns the edge arrow style. This sets the edge arrow style of custom nodes from parent to itself, and
+            overrides default `edge_arrow`
+        edge_label: ``Node`` attribute for edge label from parent to itself
+        node_attr: If string type, it refers to ``Node`` attribute for node style. If callable type, it takes in the node itself and
+            returns the node style. This overrides `node_colour`, `node_border_colour`, and `node_border_width`
 
     Returns:
-        (str)
+        Mermaid string of tree
     """
     from bigtree.tree.helper import clone_tree
 
@@ -731,13 +723,13 @@ def tree_to_mermaid(
         """Construct style for Mermaid.
 
         Args:
-            _style_name (str): style name
-            _node_colour (str): node colour
-            _node_border_colour (str): node border colour
-            _node_border_width (float): node border width
+            _style_name: style name
+            _node_colour: node colour
+            _node_border_colour: node border colour
+            _node_border_width: node border width
 
         Returns:
-            (str)
+            Style
         """
         style = []
         if _node_colour:
@@ -763,7 +755,7 @@ def tree_to_mermaid(
             """Reference name for MermaidNode, must be unique for each node.
 
             Returns:
-                (str)
+                Name of mermaid node
             """
             if self.is_root:
                 return "0"
@@ -777,12 +769,12 @@ def tree_to_mermaid(
         """Get custom attribute if available, otherwise return default parameter.
 
         Args:
-            _node (MermaidNode): node to get custom attribute, can be accessed as node attribute or a callable that takes in the node
-            attr_parameter (str | Callable): custom attribute parameter
-            default_parameter (str): default parameter if there is no attr_parameter
+            _node: node to get custom attribute, can be accessed as node attribute or a callable that takes in the node
+            attr_parameter: custom attribute parameter
+            default_parameter: default parameter if there is no attr_parameter
 
         Returns:
-            (str)
+            Node attribute
         """
         _choice = default_parameter
         if attr_parameter:

--- a/bigtree/tree/export/stdout.py
+++ b/bigtree/tree/export/stdout.py
@@ -30,8 +30,7 @@ def print_tree(
     style: Union[str, Iterable[str], constants.BasePrintStyle] = "const",
     **kwargs: Any,
 ) -> None:
-    """Print tree to console, starting from `tree`.
-    Accepts kwargs for print() function.
+    """Print tree to console, starting from `tree`. Accepts kwargs for print() function.
 
     - Able to have alias for node name if alias attribute is present, else it falls back to node_name, using `alias`
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
@@ -170,16 +169,15 @@ def print_tree(
         <BLANKLINE>
 
     Args:
-        tree (Node): tree to print
-        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node
-        node_name_or_path (str): node to print from, becomes the root node of printing
-        max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
-        all_attrs (bool): indicator to show all attributes, defaults to False, overrides `attr_list` and `attr_omit_null`
-        attr_list (Iterable[str]): list of node attributes to print, optional
-        attr_omit_null (bool): indicator whether to omit showing of null attributes, defaults to False
-        attr_bracket (List[str]): open and close bracket for `all_attrs` or `attr_list`
-        style (Union[str, Iterable[str], constants.BasePrintStyle]): style of print, defaults to const
+        tree: tree to print
+        alias: node attribute to use for node name in tree as alias to `node_name`
+        node_name_or_path: node to print from, becomes the root node of printing
+        max_depth: maximum depth of tree to print, based on `depth` attribute
+        all_attrs: indicator to show all attributes, overrides `attr_list` and `attr_omit_null`
+        attr_list: list of node attributes to print
+        attr_omit_null: indicator whether to omit showing of null attributes
+        attr_bracket: open and close bracket for `all_attrs` or `attr_list`
+        style: style of print
     """
     for pre_str, fill_str, _node in yield_tree(
         tree=tree,
@@ -341,13 +339,13 @@ def yield_tree(
         └── c [age=60]
 
     Args:
-        tree (Node): tree to print
-        node_name_or_path (str): node to print from, becomes the root node of printing, optional
-        max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
-        style (Union[str, Iterable[str], constants.BasePrintStyle]): style of print, defaults to const
+        tree: tree to print
+        node_name_or_path: node to print from, becomes the root node of printing
+        max_depth: maximum depth of tree to print, based on `depth` attribute
+        style: style of print
 
     Returns:
-        (Iterable[Tuple[str, str, Node]])
+        Yields tree in format branch, stem, and node
     """
     from bigtree.tree.export._yield_tree import YieldTree
 
@@ -372,8 +370,7 @@ def hprint_tree(
     strip: bool = True,
     **kwargs: Any,
 ) -> None:
-    """Print tree in horizontal orientation to console, starting from `tree`.
-    Accepts kwargs for print() function.
+    """Print tree in horizontal orientation to console, starting from `tree`. Accepts kwargs for print() function.
 
     - Able to have alias for node name if alias attribute is present, else it falls back to node_name, using `alias`
     - Able to select which node to print from, resulting in a subtree, using `node_name_or_path`
@@ -491,16 +488,15 @@ def hprint_tree(
              └─ c
 
     Args:
-        tree (Node): tree to print
-        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node
-        node_name_or_path (str): node to print from, becomes the root node of printing
-        max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
-        intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
-        spacing (int): horizontal spacing between node displays
-        style (Union[str, Iterable[str], constants.BaseHPrintStyle]): style of print, defaults to const
-        border_style (Union[str, Iterable[str], constants.BorderStyle]): style of border, defaults to None
-        strip (bool): whether to strip results, defaults to True
+        tree: tree to print
+        alias: node attribute to use for node name in tree as alias to `node_name`
+        node_name_or_path: node to print from, becomes the root node of printing
+        max_depth: maximum depth of tree to print, based on `depth` attribute
+        intermediate_node_name: indicator if intermediate nodes have node names
+        spacing: horizontal spacing between node displays
+        style: style of print
+        border_style: style of border
+        strip: whether to strip results
     """
     result = hyield_tree(
         tree,
@@ -645,19 +641,18 @@ def hyield_tree(
                   ╰───────╯
 
     Args:
-        tree (Node): tree to print
-        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node
-        node_name_or_path (str): node to print from, becomes the root node of printing
-        max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
-        intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
-        spacing (int): horizontal spacing between node displays
-        style (Union[str, Iterable[str], constants.BaseHPrintStyle]): style of print, defaults to const
-        border_style (Union[str, Iterable[str], constants.BorderStyle]): style of border, defaults to None
-        strip (bool): whether to strip results, defaults to True
+        tree: tree to print
+        alias: node attribute to use for node name in tree as alias to `node_name`
+        node_name_or_path: node to print from, becomes the root node of printing
+        max_depth: maximum depth of tree to print, based on `depth` attribute
+        intermediate_node_name: indicator if intermediate nodes have node names
+        spacing: horizontal spacing between node displays
+        style: style of print
+        border_style: style of border
+        strip: whether to strip results
 
     Returns:
-        (List[str])
+        Yield tree in horizontal format
     """
     from bigtree.tree.export._yield_tree import HYieldTree
 
@@ -870,19 +865,15 @@ def vprint_tree(
         └───┘  └───┘
 
     Args:
-        tree (Node): tree to print
-        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node
-        node_name_or_path (str): node to print from, becomes the root node of printing
-        max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
-        intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
-        spacing (int): horizontal spacing between node displays
-        style (Union[str, Iterable[str], constants.BaseVPrintStyle]): style of print, defaults to const
-        border_style (Union[str, Iterable[str], constants.BorderStyle]): style of border, defaults to const
-        strip (bool): whether to strip results, defaults to False
-
-    Returns:
-        (List[str])
+        tree: tree to print
+        alias: node attribute to use for node name in tree as alias to `node_name`
+        node_name_or_path: node to print from, becomes the root node of printing
+        max_depth: maximum depth of tree to print, based on `depth` attribute
+        intermediate_node_name: indicator if intermediate nodes have node names
+        spacing: horizontal spacing between node displays
+        style: style of print
+        border_style: style of border
+        strip: whether to strip results
     """
     result = vyield_tree(
         tree,
@@ -1084,19 +1075,18 @@ def vyield_tree(
         ╰───╯  ╰───╯
 
     Args:
-        tree (Node): tree to print
-        alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node
-        node_name_or_path (str): node to print from, becomes the root node of printing
-        max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
-        intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
-        spacing (int): horizontal spacing between node displays
-        style (Union[str, Iterable[str], constants.BaseHPrintStyle]): style of print, defaults to const
-        border_style (Union[str, Iterable[str], constants.BorderStyle]): style of border, defaults to const
-        strip (bool): whether to strip results, defaults to False
+        tree: tree to print
+        alias: node attribute to use for node name in tree as alias to `node_name`
+        node_name_or_path: node to print from, becomes the root node of printing
+        max_depth: maximum depth of tree to print, based on `depth` attribute
+        intermediate_node_name: indicator if intermediate nodes have node names
+        spacing: horizontal spacing between node displays
+        style: style of print
+        border_style: style of border
+        strip: whether to strip results
 
     Returns:
-        (List[str])
+        Yield tree in vertical format
     """
     from bigtree.tree.export._yield_tree import VYieldTree
 
@@ -1160,16 +1150,16 @@ def tree_to_newick(
         '((d:40[&&NHX:species=human],e:35[&&NHX:species=human])b:65[&&NHX:species=human],c:60[&&NHX:species=human])a[&&NHX:species=human]'
 
     Args:
-        tree (Node): tree to be exported
-        intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
-        length_attr (str): node length attribute to extract to beside name, optional
-        length_sep (str): separator between node name and length, used if length_attr is non-empty, defaults to ":"
-        attr_list (Iterable[str]): list of node attributes to extract into square bracket, optional
-        attr_prefix (str): prefix before all attributes, within square bracket, used if attr_list is non-empty, defaults to "&&NHX:"
-        attr_sep (str): separator between attributes, within square brackets, used if attr_list is non-empty, defaults to ":"
+        tree: tree to be exported
+        intermediate_node_name: indicator if intermediate nodes have node names
+        length_attr: node length attribute to extract to beside name
+        length_sep: separator between node name and length, used if length_attr is non-empty
+        attr_list: list of node attributes to extract into square bracket
+        attr_prefix: prefix before all attributes, within square bracket, used if attr_list is non-empty
+        attr_sep: separator between attributes, within square brackets, used if attr_list is non-empty
 
     Returns:
-        (str)
+        Newick string representation of tree
     """
     if not tree:
         return ""

--- a/bigtree/tree/export/stdout.py
+++ b/bigtree/tree/export/stdout.py
@@ -348,7 +348,7 @@ def yield_tree(
         style (Union[str, Iterable[str], constants.BasePrintStyle]): style of print, defaults to const
 
     Returns:
-        (Iterable[Tuple[str, str, T]])
+        (Iterable[Tuple[str, str, Node]])
     """
     from bigtree.tree.helper import get_subtree
 

--- a/bigtree/tree/export/stdout.py
+++ b/bigtree/tree/export/stdout.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import collections
-from typing import Any, Iterable, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Iterable, List, Optional, Tuple, TypeVar, Union
 
 from bigtree.node import node
-from bigtree.utils import assertions, constants, iterators
+from bigtree.utils import assertions, constants
 
 __all__ = [
     "print_tree",
@@ -173,7 +172,7 @@ def print_tree(
     Args:
         tree (Node): tree to print
         alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node.
+            Otherwise, it will default to `node_name` of node
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         all_attrs (bool): indicator to show all attributes, defaults to False, overrides `attr_list` and `attr_omit_null`
@@ -350,42 +349,15 @@ def yield_tree(
     Returns:
         (Iterable[Tuple[str, str, Node]])
     """
-    from bigtree.tree.helper import get_subtree
+    from bigtree.tree.export._yield_tree import YieldTree
 
-    tree = get_subtree(tree, node_name_or_path, max_depth)
-
-    # Set style
-    style_class: constants.BasePrintStyle = __get_style_class(
-        constants.BasePrintStyle, style, "style"
-    )  # type: ignore
-
-    gap_str = " " * len(style_class.STEM)
-    unclosed_depth = set()
-    initial_depth = tree.depth
-    for _node in iterators.preorder_iter(tree, max_depth=max_depth):
-        pre_str = ""
-        fill_str = ""
-        if not _node.is_root:
-            node_depth = _node.depth - initial_depth
-
-            # Get fill_str (style_branch or style_stem_final)
-            if _node.right_sibling:
-                unclosed_depth.add(node_depth)
-                fill_str = style_class.BRANCH
-            else:
-                if node_depth in unclosed_depth:
-                    unclosed_depth.remove(node_depth)
-                fill_str = style_class.STEM_FINAL
-
-            # Get pre_str (style_stem, style_branch, style_stem_final, or gap)
-            pre_str = ""
-            for _depth in range(1, node_depth):
-                if _depth in unclosed_depth:
-                    pre_str += style_class.STEM
-                else:
-                    pre_str += gap_str
-
-        yield pre_str, fill_str, _node
+    yield_class = YieldTree(
+        tree,
+        node_name_or_path,
+        max_depth,
+        style,
+    )
+    yield from yield_class.yield_tree()
 
 
 def hprint_tree(
@@ -521,7 +493,7 @@ def hprint_tree(
     Args:
         tree (Node): tree to print
         alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node.
+            Otherwise, it will default to `node_name` of node
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
@@ -675,7 +647,7 @@ def hyield_tree(
     Args:
         tree (Node): tree to print
         alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node.
+            Otherwise, it will default to `node_name` of node
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
@@ -687,153 +659,19 @@ def hyield_tree(
     Returns:
         (List[str])
     """
-    from bigtree.tree.export._stdout import (
-        calculate_stem_pos,
-        format_node,
-        horizontal_join,
-        vertical_join,
+    from bigtree.tree.export._yield_tree import HYieldTree
+
+    yield_class = HYieldTree(
+        tree,
+        alias,
+        node_name_or_path,
+        max_depth,
+        intermediate_node_name,
+        spacing,
+        style,
+        border_style,
     )
-    from bigtree.tree.helper import get_subtree
-
-    tree = get_subtree(tree, node_name_or_path, max_depth)
-
-    # Set style
-    style_class: constants.BaseHPrintStyle = __get_style_class(
-        constants.BaseHPrintStyle, style, "style"
-    )  # type: ignore
-    border_style_class: Optional[constants.BorderStyle] = None
-    if border_style:
-        border_style_class = __get_style_class(
-            constants.BorderStyle, border_style, "border_style"
-        )  # type: ignore
-
-    # Calculate padding
-    space = " "
-    padding_depths = collections.defaultdict(int)
-    if intermediate_node_name:
-        for _idx, _children in enumerate(iterators.levelordergroup_iter(tree)):
-            padding_depths[_idx + 1] = max(
-                [
-                    len(
-                        format_node(
-                            _node,
-                            alias,
-                            intermediate_node_name,
-                            style_class,
-                            border_style_class,
-                            add_buffer=False,
-                        )[0]
-                    )
-                    for _node in _children
-                ]
-            )
-
-    def _hprint_branch(
-        _node: Union[T, node.Node], _cur_depth: int
-    ) -> Tuple[List[str], int]:
-        """Get string for tree horizontally.
-        Recursively iterate the nodes in post-order traversal manner.
-
-        Args:
-            _node (Node): node to get string
-            _cur_depth (int): current depth of node
-
-        Returns:
-            (Tuple[List[str], int]): Intermediate/final result for node, index of branch
-        """
-        if not _node:
-            # For binary node
-            _node = node.Node(" ")
-        node_display_lines = format_node(
-            _node,
-            alias,
-            intermediate_node_name,
-            style_class,
-            border_style_class,
-            padding_depths[_cur_depth],
-        )
-        node_mid = calculate_stem_pos(len(node_display_lines))
-
-        children = list(_node.children) if any(list(_node.children)) else []
-        if not len(children):
-            return node_display_lines, node_mid
-
-        result_children, result_idx = [], []
-        cumulative_height = 0
-        for idx, child in enumerate(children):
-            result_child, result_branch_idx = _hprint_branch(child, _cur_depth + 1)
-            result_idx.append(cumulative_height + result_branch_idx)
-            cumulative_height += len(result_child)
-            result_children.append(result_child)
-
-        # Join children column
-        children_display_lines = vertical_join(result_children)
-
-        # Calculate index of first branch, last branch, total length, and midpoint
-        first, last, total = (
-            result_idx[0],
-            result_idx[-1],
-            len(children_display_lines),
-        )
-        mid = (first + last) // 2
-
-        if len(children) == 1:
-            # Special case for one child (need only one branch)
-            line = space * first + style_class.BRANCH + space * (total - first - 1)
-            line_prefix = line_suffix = line
-        elif len(children) == 2 and (last - first == 1):
-            # Special case for two children (need split_branch)
-            # Create gap if two children occupy two rows
-            children_display_lines.insert(last, "")
-            last = first + 2
-            mid = (last - first) // 2
-            line_prefix = space * (first + 1) + style_class.BRANCH + space
-            line = (
-                space * first
-                + style_class.FIRST_CHILD
-                + style_class.SPLIT_BRANCH
-                + style_class.LAST_CHILD
-            )
-            line_suffix = (
-                space * first + style_class.BRANCH + space + style_class.BRANCH
-            )
-        else:
-            line_prefix = space * (first + 1)
-            line = space * first + style_class.FIRST_CHILD
-            line_suffix = space * first + style_class.BRANCH
-            for idx, (bef, aft) in enumerate(zip(result_idx, result_idx[1:])):
-                line_prefix += space * (aft - bef)
-                line += (
-                    style_class.STEM * (aft - bef - 1) + style_class.SUBSEQUENT_CHILD
-                )
-                line_suffix += space * (aft - bef - 1) + style_class.BRANCH
-            line = line[:-1] + style_class.LAST_CHILD
-            line_suffix = line_suffix[:-1] + style_class.BRANCH
-            if mid in result_idx:
-                stem = style_class.MIDDLE_CHILD if mid else style_class.FIRST_CHILD
-            else:
-                stem = style_class.SPLIT_BRANCH
-            line_prefix = (
-                line_prefix[:mid] + style_class.BRANCH + line_prefix[mid + 1 :]  # noqa
-            )
-            line = line[:mid] + stem + line[mid + 1 :]  # noqa
-        display_buffer = max(0, mid - node_mid)
-        line_buffer = max(0, node_mid - mid)
-        node_display_buffer = [len(node_display_lines[0]) * space] * display_buffer
-        child_display_buffer = [len(children_display_lines[0]) * space] * line_buffer
-        result = horizontal_join(
-            [node_display_buffer + node_display_lines]
-            + [list(" " * line_buffer + line_prefix)] * spacing
-            + [list(" " * line_buffer + line)]
-            + [list(" " * line_buffer + line_suffix)] * spacing
-            + [child_display_buffer + children_display_lines]
-        )
-        return result, mid + line_buffer
-
-    result_tree, _ = _hprint_branch(tree, 1)
-    if strip:
-        return [result.rstrip() for result in result_tree]
-    return result_tree
+    return yield_class.yield_tree(strip)
 
 
 def vprint_tree(
@@ -1034,7 +872,7 @@ def vprint_tree(
     Args:
         tree (Node): tree to print
         alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node.
+            Otherwise, it will default to `node_name` of node
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
@@ -1248,7 +1086,7 @@ def vyield_tree(
     Args:
         tree (Node): tree to print
         alias (str): node attribute to use for node name in tree as alias to `node_name`, if present.
-            Otherwise, it will default to `node_name` of node.
+            Otherwise, it will default to `node_name` of node
         node_name_or_path (str): node to print from, becomes the root node of printing
         max_depth (int): maximum depth of tree to print, based on `depth` attribute, optional
         intermediate_node_name (bool): indicator if intermediate nodes have node names, defaults to True
@@ -1260,107 +1098,19 @@ def vyield_tree(
     Returns:
         (List[str])
     """
-    from bigtree.tree.export._stdout import (
-        calculate_stem_pos,
-        format_node,
-        horizontal_join,
-        vertical_join,
+    from bigtree.tree.export._yield_tree import VYieldTree
+
+    yield_class = VYieldTree(
+        tree,
+        alias,
+        node_name_or_path,
+        max_depth,
+        intermediate_node_name,
+        spacing,
+        style,
+        border_style,
     )
-    from bigtree.tree.helper import get_subtree
-
-    tree = get_subtree(tree, node_name_or_path, max_depth)
-
-    # Set style
-    style_class: constants.BaseVPrintStyle = __get_style_class(
-        constants.BaseVPrintStyle, style, "style"
-    )  # type: ignore
-    border_style_class: Optional[constants.BorderStyle] = None
-    if border_style:
-        border_style_class = __get_style_class(
-            constants.BorderStyle, border_style, "border_style"
-        )  # type: ignore
-
-    space = " "
-
-    def _vprint_branch(_node: Union[T, node.Node]) -> Tuple[List[str], int]:
-        """Get string for tree vertically.
-        Recursively iterate the nodes in post-order traversal manner.
-
-        Args:
-            _node (Node): node to get string
-
-        Returns:
-            (Tuple[List[str], int]): Intermediate/final result for node, index of branch
-        """
-        if not _node:
-            # For binary node
-            _node = node.Node(" ", parent=node.Node(" "))
-        node_display_lines = format_node(
-            _node, alias, intermediate_node_name, style_class, border_style_class
-        )
-        node_width = len(node_display_lines[0])
-        node_mid = calculate_stem_pos(node_width)
-
-        children = list(_node.children) if any(list(_node.children)) else []
-        if not len(children):
-            return node_display_lines, node_mid
-
-        result_children, result_idx = [], []
-        cumulative_width = 0
-        for idx, child in enumerate(children):
-            result_child, result_branch_idx = _vprint_branch(child)
-            result_idx.append(cumulative_width + result_branch_idx)
-            cumulative_width += len(result_child[0]) + spacing
-            result_children.append(result_child)
-
-        # Join children row
-        children_display_lines = horizontal_join(result_children, spacing)
-
-        # Calculate index of first branch, last branch, total length, and midpoint
-        first, last, total = (
-            result_idx[0],
-            result_idx[-1],
-            len(children_display_lines[0]),
-        )
-        mid = (first + last) // 2
-
-        if len(children) == 1:
-            # Special case for one child (need only one branch)
-            line = space * first + style_class.BRANCH + space * (total - first - 1)
-        else:
-            line = space * first + style_class.FIRST_CHILD
-            for idx, (bef, aft) in enumerate(zip(result_idx, result_idx[1:])):
-                line += style_class.STEM * (aft - bef - 1)
-                line += style_class.SUBSEQUENT_CHILD
-            line = line[:-1] + style_class.LAST_CHILD
-            line += space * (total - result_idx[-1] - 1)
-            stem = (
-                style_class.MIDDLE_CHILD
-                if mid in result_idx
-                else style_class.SPLIT_BRANCH
-            )
-            line = line[:mid] + stem + line[mid + 1 :]  # noqa
-        display_buffer = max(0, mid - node_mid)
-        line_buffer = max(0, node_mid - mid)
-        result = vertical_join(
-            [
-                [
-                    display_buffer * space + result_line
-                    for result_line in node_display_lines
-                ],
-                [line_buffer * space + line],
-                [
-                    line_buffer * space + result_line
-                    for result_line in children_display_lines
-                ],
-            ]
-        )
-        return result, mid + line_buffer
-
-    result_tree, _ = _vprint_branch(tree)
-    if strip:
-        return [result.rstrip() for result in result_tree]
-    return result_tree
+    return yield_class.yield_tree(strip)
 
 
 def tree_to_newick(
@@ -1479,34 +1229,3 @@ def tree_to_newick(
         for child in tree.children
     )
     return f"({children_newick}){node_name_str}{attr_str}"
-
-
-def __get_style_class(
-    base_style: Type[constants.BaseStyle],
-    style: Union[
-        str,
-        Iterable[str],
-        constants.BaseStyle,
-    ],
-    param_name: str,
-) -> constants.BaseStyle:
-    """Get style class from style, which can be a string, style_class, or list of input to style_class
-
-    Args:
-        base_style: style class to return
-        style: style of print
-        param_name: parameter name for error message
-
-    Returns:
-        style class
-    """
-    if isinstance(style, str):
-        return base_style.from_style(style)
-    elif isinstance(style, Iterable):
-        n_fields = len(base_style.__dict__["__dataclass_fields__"])
-        if len(list(style)) != n_fields:
-            raise ValueError(
-                f"Please specify the style of {n_fields} icons in `{param_name}`"
-            )
-        return base_style(*style)
-    return style

--- a/bigtree/tree/helper.py
+++ b/bigtree/tree/helper.py
@@ -35,11 +35,11 @@ def clone_tree(tree: basenode.BaseNode, node_type: Type[BaseNodeT]) -> BaseNodeT
         Node(/a, )
 
     Args:
-        tree (BaseNode): tree to be cloned, must inherit from BaseNode
-        node_type (Type[BaseNode]): type of cloned tree
+        tree: tree to be cloned, must inherit from BaseNode
+        node_type: type of cloned tree
 
     Returns:
-        (BaseNode)
+        Cloned tree
     """
     assertions.assert_tree_type(tree, basenode.BaseNode, "BaseNode")
 
@@ -53,8 +53,8 @@ def clone_tree(tree: basenode.BaseNode, node_type: Type[BaseNodeT]) -> BaseNodeT
         """Recursively clone current node
 
         Args:
-            _new_parent_node (BaseNode): cloned parent node
-            _parent_node (BaseNode): parent node to be cloned
+            _new_parent_node: cloned parent node
+            _parent_node: parent node to be cloned
         """
         for _child in _parent_node.children:
             if _child:
@@ -97,12 +97,12 @@ def get_subtree(
         └── d
 
     Args:
-        tree (Node): existing tree
-        node_name_or_path (str): node name or path to get subtree, defaults to None
-        max_depth (int): maximum depth of subtree, based on `depth` attribute, defaults to None
+        tree: existing tree
+        node_name_or_path: node name or path to get subtree
+        max_depth: maximum depth of subtree, based on `depth` attribute
 
     Returns:
-        (Node)
+        Subtree
     """
     tree_sep = tree.sep
     tree = tree.copy()
@@ -195,14 +195,14 @@ def prune_tree(
         └── e
 
     Args:
-        tree (Union[BinaryNode, Node]): existing tree
-        prune_path (List[str] | str): prune path(s), all siblings along the prune path(s) will be removed
-        exact (bool): prune path(s) to be exactly the path, defaults to False (descendants of the path are retained)
-        sep (str): path separator of `prune_path`
-        max_depth (int): maximum depth of pruned tree, based on `depth` attribute, defaults to None
+        tree: existing tree
+        prune_path: prune path(s), all siblings along the prune path(s) will be removed
+        exact: prune path(s) to be exactly the path and remove descendants
+        sep: path separator of `prune_path`
+        max_depth: maximum depth of pruned tree, based on `depth` attribute
 
     Returns:
-        (Union[BinaryNode, Node])
+        Pruned tree
     """
     if isinstance(prune_path, str):
         prune_path = [prune_path] if prune_path else []
@@ -329,28 +329,27 @@ def get_tree_diff_dataframe(
         - Node names in tree and other_tree must not contain the `sep` (or fallback sep) symbol
 
     Args:
-        tree (Node): tree to be compared against
-        other_tree (Node): tree to be compared with
-        only_diff (bool): if aggregate and only_diff are True, child nodes that are moved from tree will be removed
-        detail (bool): by default, suffix column will display "+" and "-". If detail is True, suffix column will be more
+        tree: tree to be compared against
+        other_tree: tree to be compared with
+        only_diff: if aggregate and only_diff are True, child nodes that are moved from tree will be removed
+        detail: by default, suffix column will display "+" and "-". If detail is True, suffix column will be more
             detailed, displaying "moved from" / "moved to" / "added" / "removed" instead
-        aggregate (bool): by default, all nodes that are different will have suffix specified. If aggregate is True,
-            only parent-level node have suffixes and nodes that have different paths but same parent will not have suffix.
-        attr_list (List[str]): tree attributes to retrieve from tree and other_tree, defaults to empty list
-        fallback_sep (str): sep to fall back to if tree and other_tree has sep that clashes with symbols "+" / "-" / "~".
-            All node names in tree and other_tree should not contain this fallback_sep, defaults to "/"
-        name_col (str): name column of return dataframe, indicates the name of node
-        path_col (str): path column of return dataframe, indicates the full path of node
-        parent_col (str): parent column of return dataframe, indicates the parent name of node
-        indicator_col (str): indicator column of return dataframe, indicates whether node appears in left_only, right_only
+        aggregate: by default, all nodes that are different will have suffix specified. If aggregate is True,
+            only parent-level node have suffixes and nodes that have different paths but same parent will not have suffix
+        attr_list: tree attributes to retrieve from tree and other_tree
+        fallback_sep: sep to fall back to if tree and other_tree has sep that clashes with symbols "+" / "-" / "~".
+            All node names in tree and other_tree should not contain this fallback_sep
+        name_col: name column of return dataframe, indicates the name of node
+        path_col: path column of return dataframe, indicates the full path of node
+        parent_col: parent column of return dataframe, indicates the parent name of node
+        indicator_col: indicator column of return dataframe, indicates whether node appears in left_only, right_only
             or both tree
-        old_suffix (str): suffix given to attributes from tree of return dataframe, relevant if attr_list is specified
-        new_suffix (str): suffix given to attributes from other_tree of return dataframe, relevant if attr_list is specified
-        suffix_col (str): suffix column of return dataframe, indicates the type of diff whether it is added, removed,
-            or moved
+        old_suffix: suffix given to attributes from tree of return dataframe, relevant if attr_list is specified
+        new_suffix: suffix given to attributes from other_tree of return dataframe, relevant if attr_list is specified
+        suffix_col: suffix column of return dataframe, indicates the type of diff whether it is added, removed, or moved
 
     Returns:
-        (pd.DataFrame)
+        Dataframe of tree differences
     """
     if tree.sep != other_tree.sep:
         raise ValueError("`sep` must be the same for tree and other_tree")
@@ -593,17 +592,17 @@ def get_tree_diff(
         - Node names in tree and other_tree must not contain the `sep` (or fallback sep) symbol
 
     Args:
-        tree (Node): tree to be compared against
-        other_tree (Node): tree to be compared with
-        only_diff (bool): indicator to show all nodes or only nodes that are different (+/-), defaults to True
-        detail (bool): indicator to differentiate between different types of diff e.g., added or removed or moved
-        aggregate (bool): indicator to only add difference indicator to parent-level e.g., when shifting subtrees
-        attr_list (List[str]): tree attributes to check for difference, defaults to empty list
-        fallback_sep (str): sep to fall back to if tree and other_tree has sep that clashes with symbols "+" / "-" / "~".
-            All node names in tree and other_tree should not contain this fallback_sep, defaults to "/"
+        tree: tree to be compared against
+        other_tree: tree to be compared with
+        only_diff: indicator to show all nodes or only nodes that are different (+/-)
+        detail: indicator to differentiate between different types of diff e.g., added or removed or moved
+        aggregate: indicator to only add difference indicator to parent-level e.g., when shifting subtrees
+        attr_list: tree attributes to check for difference
+        fallback_sep: sep to fall back to if tree and other_tree has sep that clashes with symbols "+" / "-" / "~".
+            All node names in tree and other_tree should not contain this fallback_sep
 
     Returns:
-        (Node)
+        Tree highlighting the difference between tree and other_tree
     """
     name_col = "name"
     path_col = "path"

--- a/bigtree/tree/modify.py
+++ b/bigtree/tree/modify.py
@@ -1392,7 +1392,7 @@ def replace_logic(
         sep: path separator for input paths, applies to `from_path` and `to_path`
         copy: indicator to copy node
         skippable: indicator to skip if from-path is not found
-        delete_children: indicator to shift node only without children
+        delete_children: indicator to copy/shift node only without children
         to_tree: tree to copy to
         with_full_path: indicator to copy/shift node with full path in `from_paths`, results in faster search
     """

--- a/bigtree/tree/modify.py
+++ b/bigtree/tree/modify.py
@@ -258,21 +258,17 @@ def shift_nodes(
         └── Applications
 
     Args:
-        tree (Node): tree to modify
-        from_paths (List[str]): original paths to shift nodes from
-        to_paths (List[Optional[str]]): new paths to shift nodes to
-        sep (str): path separator for input paths, applies to `from_path` and `to_path`
-        skippable (bool): indicator to skip if from-path is not found, defaults to False
-        overriding (bool): indicator to override existing to-path if there are clashes, defaults to False
-        merge_attribute (bool): indicator to merge attributes of from-path and to-path if there are clashes, defaults
-            to False
-        merge_children (bool): indicator to merge from-path's children and remove intermediate parent node, defaults to
-            False
-        merge_leaves (bool): indicator to merge from-path's leaf nodes and remove intermediate parent node(s), defaults
-            to False
-        delete_children (bool): indicator to shift node only without children, defaults to False
-        with_full_path (bool): indicator to shift node with full path in `from_paths`, results in faster search,
-            defaults to False
+        tree: tree to modify
+        from_paths: original paths to shift nodes from
+        to_paths: new paths to shift nodes to
+        sep: path separator for input paths, applies to `from_path` and `to_path`
+        skippable: indicator to skip if from-path is not found
+        overriding: indicator to override existing to-path if there are clashes
+        merge_attribute: indicator to merge attributes of from-path and to-path if there are clashes
+        merge_children: indicator to merge from-path's children and remove intermediate parent node
+        merge_leaves: indicator to merge from-path's leaf nodes and remove intermediate parent node(s)
+        delete_children: indicator to shift node only without children
+        with_full_path: indicator to shift node with full path in `from_paths`, results in faster search
     """
     return copy_or_shift_logic(
         tree=tree,
@@ -528,21 +524,17 @@ def copy_nodes(
         └── Applications
 
     Args:
-        tree (Node): tree to modify
-        from_paths (List[str]): original paths to shift nodes from
-        to_paths (List[Optional[str]]): new paths to shift nodes to
-        sep (str): path separator for input paths, applies to `from_path` and `to_path`
-        skippable (bool): indicator to skip if from path is not found, defaults to False
-        overriding (bool): indicator to override existing to path if there is clashes, defaults to False
-        merge_attribute (bool): indicator to merge attributes of from-path and to-path if there are clashes, defaults
-            to False
-        merge_children (bool): indicator to merge from-path's children and remove intermediate parent node, defaults to
-            False
-        merge_leaves (bool): indicator to merge from-path's leaf nodes and remove intermediate parent node(s), defaults
-            to False
-        delete_children (bool): indicator to copy node only without children, defaults to False
-        with_full_path (bool): indicator to copy node with full path in `from_paths`, results in faster search,
-            defaults to False
+        tree: tree to modify
+        from_paths: original paths to copy nodes from
+        to_paths: new paths to copy nodes to
+        sep: path separator for input paths, applies to `from_path` and `to_path`
+        skippable: indicator to skip if from-path is not found
+        overriding: indicator to override existing to-path if there are clashes
+        merge_attribute: indicator to merge attributes of from-path and to-path if there are clashes
+        merge_children: indicator to merge from-path's children and remove intermediate parent node
+        merge_leaves: indicator to merge from-path's leaf nodes and remove intermediate parent node(s)
+        delete_children: indicator to copy node only without children
+        with_full_path: indicator to copy node with full path in `from_paths`, results in faster search
     """
     return copy_or_shift_logic(
         tree=tree,
@@ -637,14 +629,13 @@ def shift_and_replace_nodes(
             └── Pictures
 
     Args:
-        tree (Node): tree to modify
-        from_paths (List[str]): original paths to shift nodes from
-        to_paths (List[str]): new paths to shift nodes to
-        sep (str): path separator for input paths, applies to `from_path` and `to_path`
-        skippable (bool): indicator to skip if from path is not found, defaults to False
-        delete_children (bool): indicator to shift node only without children, defaults to False
-        with_full_path (bool): indicator to shift node with full path in `from_paths`, results in faster search,
-            defaults to False
+        tree: tree to modify
+        from_paths: original paths to shift nodes from
+        to_paths: new paths to shift nodes to
+        sep: path separator for input paths, applies to `from_path` and `to_path`
+        skippable: indicator to skip if from-path is not found
+        delete_children: indicator to shift node only without children
+        with_full_path: indicator to shift node with full path in `from_paths`, results in faster search
     """
     return replace_logic(
         tree=tree,
@@ -855,22 +846,18 @@ def copy_nodes_from_tree_to_tree(
         └── Misc
 
     Args:
-        from_tree (Node): tree to copy nodes from
-        to_tree (Node): tree to copy nodes to
-        from_paths (List[str]): original paths to shift nodes from
-        to_paths (List[Optional[str]]): new paths to shift nodes to
-        sep (str): path separator for input paths, applies to `from_path` and `to_path`
-        skippable (bool): indicator to skip if from path is not found, defaults to False
-        overriding (bool): indicator to override existing to path if there is clashes, defaults to False
-        merge_attribute (bool): indicator to merge attributes of from-path and to-path if there are clashes, defaults
-            to False
-        merge_children (bool): indicator to merge from-path's children and remove intermediate parent node, defaults to
-            False
-        merge_leaves (bool): indicator to merge from-path's leaf nodes and remove intermediate parent node(s), defaults
-            to False
-        delete_children (bool): indicator to copy node only without children, defaults to False
-        with_full_path (bool): indicator to copy node with full path in `from_paths`, results in faster search,
-            defaults to False
+        from_tree: tree to copy nodes from
+        to_tree: tree to copy nodes to
+        from_paths: original paths to copy nodes from
+        to_paths: new paths to copy nodes to
+        sep: path separator for input paths, applies to `from_path` and `to_path`
+        skippable: indicator to skip if from path is not found
+        overriding: indicator to override existing to path if there is clashes
+        merge_attribute: indicator to merge attributes of from-path and to-path if there are clashes
+        merge_children: indicator to merge from-path's children and remove intermediate parent node
+        merge_leaves: indicator to merge from-path's leaf nodes and remove intermediate parent node(s)
+        delete_children: indicator to copy node only without children
+        with_full_path: indicator to copy node with full path in `from_paths`, results in faster search
     """
     return copy_or_shift_logic(
         tree=from_tree,
@@ -995,15 +982,14 @@ def copy_and_replace_nodes_from_tree_to_tree(
         └── Misc
 
     Args:
-        from_tree (Node): tree to copy nodes from
-        to_tree (Node): tree to copy nodes to
-        from_paths (List[str]): original paths to copy nodes from
-        to_paths (List[str]): new paths to copy nodes to
-        sep (str): path separator for input paths, applies to `from_path` and `to_path`
-        skippable (bool): indicator to skip if from path is not found, defaults to False
-        delete_children (bool): indicator to copy node only without children, defaults to False
-        with_full_path (bool): indicator to copy node with full path in `from_paths`, results in faster search,
-            defaults to False
+        from_tree: tree to copy nodes from
+        to_tree: tree to copy nodes to
+        from_paths: original paths to copy nodes from
+        to_paths: new paths to copy nodes to
+        sep: path separator for input paths, applies to `from_path` and `to_path`
+        skippable: indicator to skip if from path is not found
+        delete_children: indicator to copy node only without children
+        with_full_path: indicator to copy node with full path in `from_paths`, results in faster search
     """
     return replace_logic(
         tree=from_tree,
@@ -1134,23 +1120,19 @@ def copy_or_shift_logic(
     - `overriding` and `merge_attribute` cannot be both True at the same time.
 
     Args:
-        tree (Node): tree to modify
-        from_paths (List[str]): original paths to shift nodes from
-        to_paths (List[Optional[str]]): new paths to shift nodes to
-        sep (str): path separator for input paths, applies to `from_path` and `to_path`
-        copy (bool): indicator to copy node, defaults to False
-        skippable (bool): indicator to skip if from path is not found, defaults to False
-        overriding (bool): indicator to override existing to path if there is clashes, defaults to False
-        merge_attribute (bool): indicator to merge attributes of from-path and to-path if there are clashes, defaults
-            to False
-        merge_children (bool): indicator to merge from-path's children and remove intermediate parent node, defaults to
-            False
-        merge_leaves (bool): indicator to merge from-path's leaf nodes and remove intermediate parent node(s), defaults
-            to False
-        delete_children (bool): indicator to shift/copy node only without children, defaults to False
-        to_tree (Node): tree to copy to, defaults to None
-        with_full_path (bool): indicator to shift/copy node with full path in `from_paths`, results in faster search,
-            defaults to False
+        tree: tree to modify
+        from_paths: original paths to copy/shift nodes from
+        to_paths: new paths to copy/shift nodes to
+        sep: path separator for input paths, applies to `from_path` and `to_path`
+        copy: indicator to copy node,
+        skippable: indicator to skip if from-path is not found
+        overriding: indicator to override existing to-path if there are clashes
+        merge_attribute: indicator to merge attributes of from-path and to-path if there are clashes
+        merge_children: indicator to merge from-path's children and remove intermediate parent node
+        merge_leaves: indicator to merge from-path's leaf nodes and remove intermediate parent node(s)
+        delete_children: indicator to copy/shift node only without children
+        to_tree: tree to copy to
+        with_full_path: indicator to copy/shift node with full path in `from_paths`, results in faster search
     """
     if merge_children and merge_leaves:
         raise ValueError(
@@ -1404,16 +1386,15 @@ def replace_logic(
     - Path must exist, node-to-be-replaced must be present.
 
     Args:
-        tree (Node): tree to modify
-        from_paths (List[str]): original paths to shift nodes from
-        to_paths (List[str]): new paths to shift nodes to
-        sep (str): path separator for input paths, applies to `from_path` and `to_path`
-        copy (bool): indicator to copy node, defaults to False
-        skippable (bool): indicator to skip if from path is not found, defaults to False
-        delete_children (bool): indicator to shift/copy node only without children, defaults to False
-        to_tree (Node): tree to copy to, defaults to None
-        with_full_path (bool): indicator to shift/copy node with full path in `from_paths`, results in faster search,
-            defaults to False
+        tree: tree to modify
+        from_paths: original paths to copy/shift nodes from
+        to_paths: new paths to copy/shift nodes to
+        sep: path separator for input paths, applies to `from_path` and `to_path`
+        copy: indicator to copy node
+        skippable: indicator to skip if from-path is not found
+        delete_children: indicator to shift node only without children
+        to_tree: tree to copy to
+        with_full_path: indicator to copy/shift node with full path in `from_paths`, results in faster search
     """
     if not (isinstance(from_paths, list) and isinstance(to_paths, list)):
         raise ValueError(

--- a/bigtree/tree/search.py
+++ b/bigtree/tree/search.py
@@ -32,11 +32,11 @@ def __check_result_count(
     """Check result fulfil min_count and max_count requirements
 
     Args:
-        result (Tuple[Any]): result of search
-        min_count (int): checks for minimum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
-        max_count (int): checks for maximum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
+        result: result of search
+        min_count: checks for minimum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
+        max_count: checks for maximum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
     """
     if min_count and len(result) < min_count:
         raise exceptions.SearchError(
@@ -68,16 +68,16 @@ def findall(
         (Node(/a, age=90), Node(/a/b, age=65))
 
     Args:
-        tree (BaseNode): tree to search
-        condition (Callable): function that takes in node as argument, returns node if condition evaluates to `True`
-        max_depth (int): maximum depth to search for, based on the `depth` attribute, defaults to None
-        min_count (int): checks for minimum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
-        max_count (int): checks for maximum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
+        tree: tree to search
+        condition: function that takes in node as argument, returns node if condition evaluates to `True`
+        max_depth: maximum depth to search for, based on the `depth` attribute
+        min_count: checks for minimum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
+        max_count: checks for maximum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
 
     Returns:
-        (Tuple[BaseNode, ...])
+        Search results
     """
     result = tuple(
         iterators.preorder_iter(tree, filter_condition=condition, max_depth=max_depth)
@@ -105,12 +105,12 @@ def find(tree: T, condition: Callable[[T], bool], max_depth: int = 0) -> T:
         (Node(/a, age=90), Node(/a/b, age=65), Node(/a/c, age=60), Node(/a/c/d, age=40))
 
     Args:
-        tree (BaseNode): tree to search
-        condition (Callable): function that takes in node as argument, returns node if condition evaluates to `True`
-        max_depth (int): maximum depth to search for, based on the `depth` attribute, defaults to None
+        tree: tree to search
+        condition: function that takes in node as argument, returns node if condition evaluates to `True`
+        max_depth: maximum depth to search for, based on the `depth` attribute
 
     Returns:
-        (BaseNode)
+        Search result
     """
     result = findall(tree, condition, max_depth, max_count=1)
     if result:
@@ -131,12 +131,12 @@ def find_name(tree: NodeT, name: str, max_depth: int = 0) -> NodeT:
         Node(/a/c, age=60)
 
     Args:
-        tree (Node): tree to search
-        name (str): value to match for name attribute
-        max_depth (int): maximum depth to search for, based on the `depth` attribute, defaults to None
+        tree: tree to search
+        name: value to match for name attribute
+        max_depth: maximum depth to search for, based on the `depth` attribute
 
     Returns:
-        (Node)
+        Search result
     """
     return find(tree, lambda _node: _node.node_name == name, max_depth)
 
@@ -157,12 +157,12 @@ def find_names(tree: NodeT, name: str, max_depth: int = 0) -> Iterable[NodeT]:
         (Node(/a/b, age=65), Node(/a/c/b, age=40))
 
     Args:
-        tree (Node): tree to search
-        name (str): value to match for name attribute
-        max_depth (int): maximum depth to search for, based on the `depth` attribute, defaults to None
+        tree: tree to search
+        name: value to match for name attribute
+        max_depth: maximum depth to search for, based on the `depth` attribute
 
     Returns:
-        (Iterable[Node])
+        Search results
     """
     return findall(tree, lambda _node: _node.node_name == name, max_depth)
 
@@ -192,11 +192,11 @@ def find_relative_path(tree: NodeT, path_name: str) -> NodeT:
         (Node(/a/b, age=65), Node(/a/c, age=60))
 
     Args:
-        tree (Node): tree to search
-        path_name (str): value to match (relative path) of path_name attribute
+        tree: tree to search
+        path_name: value to match (relative path) of path_name attribute
 
     Returns:
-        (Node)
+        Search result
     """
     result = find_relative_paths(tree, path_name, max_count=1)
 
@@ -231,15 +231,15 @@ def find_relative_paths(
         (Node(/a/b, age=65), Node(/a/c, age=60))
 
     Args:
-        tree (Node): tree to search
-        path_name (str): value to match (relative path) of path_name attribute
-        min_count (int): checks for minimum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
-        max_count (int): checks for maximum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
+        tree: tree to search
+        path_name: value to match (relative path) of path_name attribute
+        min_count: checks for minimum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
+        max_count: checks for maximum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
 
     Returns:
-        (Tuple[Node, ...])
+        Search results
     """
     sep = tree.sep
     if path_name.startswith(sep):
@@ -261,8 +261,8 @@ def find_relative_paths(
         """Resolve node based on path name
 
         Args:
-            _node (Node): current node
-            path_idx (int): current index in path_list
+            _node: current node
+            path_idx: current index in path_list
         """
         if path_idx == len(path_list):
             resolved_nodes.append(_node)
@@ -312,11 +312,11 @@ def find_full_path(tree: NodeT, path_name: str) -> NodeT:
         Node(/a/c/d, age=40)
 
     Args:
-        tree (Node): tree to search
-        path_name (str): value to match (full path) of path_name attribute
+        tree: tree to search
+        path_name: value to match (full path) of path_name attribute
 
     Returns:
-        (Node)
+        Search result
     """
     sep = tree.sep
     path_list = path_name.rstrip(sep).lstrip(sep).split(sep)
@@ -353,11 +353,11 @@ def find_path(tree: NodeT, path_name: str) -> NodeT:
         Node(/a/c, age=60)
 
     Args:
-        tree (Node): tree to search
-        path_name (str): value to match (full path) or trailing part (partial path) of path_name attribute
+        tree: tree to search
+        path_name: value to match (full path) or trailing part (partial path) of path_name attribute
 
     Returns:
-        (Node)
+        Search result
     """
     path_name = path_name.rstrip(tree.sep)
     return find(tree, lambda _node: _node.path_name.endswith(path_name))
@@ -382,11 +382,11 @@ def find_paths(tree: NodeT, path_name: str) -> Iterable[NodeT]:
         (Node(/a/c, age=60), Node(/a/c/c, age=40))
 
     Args:
-        tree (Node): tree to search
-        path_name (str): value to match (full path) or trailing part (partial path) of path_name attribute
+        tree: tree to search
+        path_name: value to match (full path) or trailing part (partial path) of path_name attribute
 
     Returns:
-        (Iterable[Node])
+        Search results
     """
     path_name = path_name.rstrip(tree.sep)
     return findall(tree, lambda _node: _node.path_name.endswith(path_name))
@@ -408,13 +408,13 @@ def find_attr(
         Node(/a/b, age=65)
 
     Args:
-        tree (BaseNode): tree to search
-        attr_name (str): attribute name to perform matching
-        attr_value (Any): value to match for attr_name attribute
-        max_depth (int): maximum depth to search for, based on the `depth` attribute, defaults to None
+        tree: tree to search
+        attr_name: attribute name to perform matching
+        attr_value: value to match for attr_name attribute
+        max_depth: maximum depth to search for, based on the `depth` attribute
 
     Returns:
-        (BaseNode)
+        Search result
     """
     return find(
         tree,
@@ -439,13 +439,13 @@ def find_attrs(
         (Node(/a/b, age=65), Node(/a/c, age=65))
 
     Args:
-        tree (BaseNode): tree to search
-        attr_name (str): attribute name to perform matching
-        attr_value (Any): value to match for attr_name attribute
-        max_depth (int): maximum depth to search for, based on the `depth` attribute, defaults to None
+        tree: tree to search
+        attr_name: attribute name to perform matching
+        attr_value: value to match for attr_name attribute
+        max_depth: maximum depth to search for, based on the `depth` attribute
 
     Returns:
-        (Iterable[BaseNode])
+        Search results
     """
     return findall(
         tree,
@@ -473,15 +473,15 @@ def find_children(
         (Node(/a/b, age=65), Node(/a/c, age=60))
 
     Args:
-        tree (BaseNode/DAGNode): tree to search for its children
-        condition (Callable): function that takes in node as argument, returns node if condition evaluates to `True`
-        min_count (int): checks for minimum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
-        max_count (int): checks for maximum number of occurrences,
-            raise exceptions.SearchError if the number of results do not meet min_count, defaults to None
+        tree: tree to search for its children
+        condition: function that takes in node as argument, returns node if condition evaluates to `True`
+        min_count: checks for minimum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
+        max_count: checks for maximum number of occurrences, raise exceptions.SearchError if the number of results do
+            not meet min_count
 
     Returns:
-        (Tuple[Union[BaseNode, DAGNode], ...])
+        Search results
     """
     result = tuple([_node for _node in tree.children if _node and condition(_node)])
     __check_result_count(result, min_count, max_count)
@@ -505,11 +505,11 @@ def find_child(
         Node(/a/b, age=65)
 
     Args:
-        tree (BaseNode/DAGNode): tree to search for its child
-        condition (Callable): function that takes in node as argument, returns node if condition evaluates to `True`
+        tree: tree to search for its child
+        condition: function that takes in node as argument, returns node if condition evaluates to `True`
 
     Returns:
-        (BaseNode/DAGNode)
+        Search results
     """
     result = find_children(tree, condition, max_count=1)
     if result:
@@ -534,10 +534,10 @@ def find_child_by_name(
         Node(/a/c/d, age=40)
 
     Args:
-        tree (Node/DAGNode): tree to search, parent node
-        name (str): value to match for name attribute, child node
+        tree: tree to search, parent node
+        name: value to match for name attribute, child node
 
     Returns:
-        (Node/DAGNode)
+        Search result
     """
     return find_child(tree, lambda _node: _node.node_name == name)

--- a/bigtree/tree/search.py
+++ b/bigtree/tree/search.py
@@ -509,7 +509,7 @@ def find_child(
         condition: function that takes in node as argument, returns node if condition evaluates to `True`
 
     Returns:
-        Search results
+        Search result
     """
     result = find_children(tree, condition, max_count=1)
     if result:

--- a/bigtree/utils/assertions.py
+++ b/bigtree/utils/assertions.py
@@ -42,11 +42,11 @@ def assert_style_in_dict(
     parameter: Any,
     accepted_parameters: Dict[str, Any],
 ) -> None:
-    """Raise ValueError is parameter is not in list of accepted parameters
+    """Raise ValueError is parameter is not in list of accepted parameters.
 
     Args:
-        parameter (Any): argument input for parameter
-        accepted_parameters (List[Any]): list of accepted parameters
+        parameter: argument input for parameter
+        accepted_parameters: list of accepted parameters
     """
     if parameter not in accepted_parameters:
         raise ValueError(
@@ -59,12 +59,12 @@ def assert_str_in_list(
     parameter: Any,
     accepted_parameters: List[Any],
 ) -> None:
-    """Raise ValueError is parameter is not in list of accepted parameters
+    """Raise ValueError is parameter is not in list of accepted parameters.
 
     Args:
-        parameter_name (str): parameter name for error message
-        parameter (Any): argument input for parameter
-        accepted_parameters (List[Any]): list of accepted parameters
+        parameter_name: parameter name for error message
+        parameter: argument input for parameter
+        accepted_parameters: list of accepted parameters
     """
     if parameter not in accepted_parameters:
         raise ValueError(
@@ -94,12 +94,12 @@ def assert_key_in_dict(
     parameter: Any,
     accepted_parameters: Dict[Any, Any],
 ) -> None:
-    """Raise ValueError is parameter is not in key of dictionary
+    """Raise ValueError is parameter is not in key of dictionary.
 
     Args:
-        parameter_name (str): parameter name for error message
-        parameter (Any): argument input for parameter
-        accepted_parameters (Dict[Any]): dictionary of accepted parameters
+        parameter_name: parameter name for error message
+        parameter: argument input for parameter
+        accepted_parameters: dictionary of accepted parameters
     """
     if parameter not in accepted_parameters:
         raise ValueError(
@@ -108,12 +108,12 @@ def assert_key_in_dict(
 
 
 def assert_length_not_empty(data: Sized, argument_name: str, argument: str) -> None:
-    """Raise ValueError if data does not have length
+    """Raise ValueError if data does not have length.
 
     Args:
-        data (Sized): data to check
+        data: data to check
         argument_name: argument name for data, for error message
-        argument (str): argument for data, for error message
+        argument: argument for data, for error message
     """
     if not len(data):
         raise ValueError(
@@ -122,10 +122,10 @@ def assert_length_not_empty(data: Sized, argument_name: str, argument: str) -> N
 
 
 def assert_dataframe_not_empty(data: pd.DataFrame) -> None:
-    """Raise ValueError is dataframe is empty
+    """Raise ValueError is dataframe is empty.
 
     Args:
-        data (pd.DataFrame): dataframe to check
+        data: dataframe to check
     """
     if not len(data.columns):
         raise ValueError("Data does not contain any columns, check `data`")
@@ -139,13 +139,13 @@ def assert_dataframe_no_duplicate_attribute(
     id_col: str,
     attribute_cols: List[str],
 ) -> None:
-    """Raise ValueError is dataframe contains different attributes for same path
+    """Raise ValueError is dataframe contains different attributes for same path.
 
     Args:
-        data (Union[pd.DataFrame, pl.DataFrame]): dataframe to check
-        id_type (str): type of uniqueness to check for, for error message
-        id_col (str): column of data that is unique, can be name or path
-        attribute_cols (List[str]): columns of data containing node attribute information,
+        data: dataframe to check
+        id_type: type of uniqueness to check for, for error message
+        id_col: column of data that is unique, can be name or path
+        attribute_cols: columns of data containing node attribute information
     """
     if pd and isinstance(data, pd.DataFrame):
         data_check = data[[id_col] + attribute_cols].astype(str).drop_duplicates()
@@ -172,12 +172,12 @@ def assert_dataframe_no_duplicate_children(
     child_col: str,
     parent_col: str,
 ) -> None:
-    """Raise ValueError is dataframe contains different duplicated parent tagged to different grandparents
+    """Raise ValueError is dataframe contains different duplicated parent tagged to different grandparents.
 
     Args:
-        data (Union[pd.DataFrame, pl.DataFrame]): dataframe to check
-        child_col (str): column of data containing child name information
-        parent_col (str): column of data containing parent name information
+        data: dataframe to check
+        child_col: column of data containing child name information
+        parent_col: column of data containing parent name information
     """
     # Filter for child nodes that are parent of other nodes
     if pd and isinstance(data, pd.DataFrame):
@@ -211,12 +211,12 @@ def assert_tree_type(
     tree_type: Union[Type[BaseNode], Type[Node], Type[DAGNode]],
     tree_type_name: str,
 ) -> None:
-    """Raise TypeError is tree is not of `tree_type`
+    """Raise TypeError is tree is not of `tree_type`.
 
     Args:
-        tree (Union["BaseNode", "Node", "DAGNode"]): tree to check
+        tree: tree to check
         tree_type: tree type to assert for
-        tree_type_name (str): tree type name
+        tree_type_name: tree type name
     """
     if not isinstance(tree, tree_type):
         raise TypeError(
@@ -225,13 +225,13 @@ def assert_tree_type(
 
 
 def isnull(value: Any) -> bool:
-    """Check if value is null
+    """Check if value is null.
 
     Args:
-        value (Any): value to check
+        value: value to check
 
     Returns:
-        (bool)
+        Flag if value is null
     """
     import math
 
@@ -245,15 +245,15 @@ def filter_attributes(
     omit_keys: List[str],
     omit_null_values: bool,
 ) -> Dict[str, Any]:
-    """Filter node attributes to remove certain keys and/or values
+    """Filter node attributes to remove certain keys and/or values.
 
     Args:
-        node_attributes (Dict[str, Any]): node attribute dictionary
-        omit_keys (List[str]): list of keys to omit
-        omit_null_values (bool): indicator whether to omit values that are null
+        node_attributes: node attribute dictionary
+        omit_keys: list of keys to omit
+        omit_null_values: indicator whether to omit values that are null
 
     Returns:
-        (Dict[str, Any])
+        Filtered node attributes
     """
     if omit_null_values:
         return {

--- a/bigtree/utils/constants.py
+++ b/bigtree/utils/constants.py
@@ -186,7 +186,14 @@ class ExportConstants:
 
 
 @dataclass
-class BorderStyle:
+class BaseStyle:
+    @classmethod
+    def from_style(cls, style_name: str) -> "BaseStyle":
+        raise NotImplementedError
+
+
+@dataclass
+class BorderStyle(BaseStyle):
     """Base style for `print_tree` and `yield_tree` function"""
 
     TOP_LEFT: str
@@ -215,7 +222,7 @@ class BorderStyle:
 
 
 @dataclass
-class BasePrintStyle:
+class BasePrintStyle(BaseStyle):
     """Base style for `print_tree` and `yield_tree` function"""
 
     STEM: str
@@ -235,7 +242,7 @@ class BasePrintStyle:
 
 
 @dataclass
-class BaseHPrintStyle:
+class BaseHPrintStyle(BaseStyle):
     """Base style for `hprint_tree` and `hyield_tree` function"""
 
     FIRST_CHILD: str
@@ -266,7 +273,7 @@ class BaseHPrintStyle:
 
 
 @dataclass
-class BaseVPrintStyle:
+class BaseVPrintStyle(BaseStyle):
     """Base style for `hprint_tree` and `hyield_tree` function"""
 
     FIRST_CHILD: str

--- a/bigtree/utils/constants.py
+++ b/bigtree/utils/constants.py
@@ -189,7 +189,7 @@ class ExportConstants:
 class BaseStyle:
     @classmethod
     def from_style(cls, style_name: str) -> "BaseStyle":
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 @dataclass

--- a/bigtree/utils/constants.py
+++ b/bigtree/utils/constants.py
@@ -194,7 +194,7 @@ class BaseStyle:
 
 @dataclass
 class BorderStyle(BaseStyle):
-    """Base style for `print_tree` and `yield_tree` function"""
+    """Base style for `print_tree` and `yield_tree` function."""
 
     TOP_LEFT: str
     TOP_RIGHT: str
@@ -223,7 +223,7 @@ class BorderStyle(BaseStyle):
 
 @dataclass
 class BasePrintStyle(BaseStyle):
-    """Base style for `print_tree` and `yield_tree` function"""
+    """Base style for `print_tree` and `yield_tree` function."""
 
     STEM: str
     BRANCH: str
@@ -243,7 +243,7 @@ class BasePrintStyle(BaseStyle):
 
 @dataclass
 class BaseHPrintStyle(BaseStyle):
-    """Base style for `hprint_tree` and `hyield_tree` function"""
+    """Base style for `hprint_tree` and `hyield_tree` function."""
 
     FIRST_CHILD: str
     SUBSEQUENT_CHILD: str
@@ -274,7 +274,7 @@ class BaseHPrintStyle(BaseStyle):
 
 @dataclass
 class BaseVPrintStyle(BaseStyle):
-    """Base style for `hprint_tree` and `hyield_tree` function"""
+    """Base style for `hprint_tree` and `hyield_tree` function."""
 
     FIRST_CHILD: str
     SUBSEQUENT_CHILD: str

--- a/bigtree/utils/groot.py
+++ b/bigtree/utils/groot.py
@@ -11,7 +11,7 @@ def speak_like_groot(sentence: str) -> str:
     """Convert sentence into Groot langauge.
 
     Args:
-        sentence: Sentence to convert to groot language
+        sentence: sentence to convert to groot language
 
     Returns:
         Groot string

--- a/bigtree/utils/groot.py
+++ b/bigtree/utils/groot.py
@@ -1,19 +1,19 @@
 def whoami() -> str:
-    """Groot utils
+    """Groot utils.
 
     Returns:
-        (str)
+        Groot reply
     """
     return "I am Groot!"
 
 
 def speak_like_groot(sentence: str) -> str:
-    """Convert sentence into Groot langauge
+    """Convert sentence into Groot langauge.
 
     Args:
-        sentence (str): Sentence to convert to groot language
+        sentence: Sentence to convert to groot language
 
     Returns:
-        (str)
+        Groot string
     """
     return " ".join([whoami() for _ in range(len(sentence.split()))])

--- a/bigtree/utils/iterators.py
+++ b/bigtree/utils/iterators.py
@@ -67,13 +67,12 @@ def inorder_iter(
         ['4', '2', '5', '1', '6', '3', '7']
 
     Args:
-        tree (BinaryNode): input tree
-        filter_condition (Optional[Callable[[BinaryNode], bool]]): function that takes in node as argument, optional
-            Return node if condition evaluates to `True`
-        max_depth (int): maximum depth of iteration, based on `depth` attribute, optional
+        tree: input tree
+        filter_condition: function that takes in node as argument. Return node if condition evaluates to `True`
+        max_depth: maximum depth of iteration, based on `depth` attribute
 
     Returns:
-        (Iterable[BinaryNode])
+        Iterable of nodes
     """
     if tree and (not max_depth or not tree.depth > max_depth):
         yield from inorder_iter(tree.left, filter_condition, max_depth)
@@ -124,15 +123,13 @@ def preorder_iter(
         ['a', 'b', 'd', 'e', 'c', 'f']
 
     Args:
-        tree (Union[BaseNode, DAGNode]): input tree
-        filter_condition (Optional[Callable[[T], bool]]): function that takes in node as argument, optional
-            Return node if condition evaluates to `True`
-        stop_condition (Optional[Callable[[T], bool]]): function that takes in node as argument, optional
-            Stops iteration if condition evaluates to `True`
-        max_depth (int): maximum depth of iteration, based on `depth` attribute, optional
+        tree: input tree
+        filter_condition: function that takes in node as argument. Return node if condition evaluates to `True`
+        stop_condition: function that takes in node as argument. Stops iteration if condition evaluates to `True`
+        max_depth: maximum depth of iteration, based on `depth` attribute
 
     Returns:
-        (Union[Iterable[BaseNode], Iterable[DAGNode]])
+        Iterable of nodes
     """
     if (
         tree
@@ -185,15 +182,13 @@ def postorder_iter(
         ['d', 'e', 'b', 'f', 'c', 'a']
 
     Args:
-        tree (BaseNode): input tree
-        filter_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Return node if condition evaluates to `True`
-        stop_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Stops iteration if condition evaluates to `True`
-        max_depth (int): maximum depth of iteration, based on `depth` attribute, optional
+        tree: input tree
+        filter_condition: function that takes in node as argument. Return node if condition evaluates to `True`
+        stop_condition: function that takes in node as argument. Stops iteration if condition evaluates to `True`
+        max_depth: maximum depth of iteration, based on `depth` attribute
 
     Returns:
-        (Iterable[BaseNode])
+        Iterable of nodes
     """
     if (
         tree
@@ -246,15 +241,13 @@ def levelorder_iter(
         ['a', 'b', 'c', 'd', 'e', 'f']
 
     Args:
-        tree (BaseNode): input tree
-        filter_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Return node if condition evaluates to `True`
-        stop_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Stops iteration if condition evaluates to `True`
-        max_depth (int): maximum depth of iteration, based on `depth` attribute, defaults to None
+        tree: input tree
+        filter_condition: function that takes in node as argument. Return node if condition evaluates to `True`
+        stop_condition: function that takes in node as argument. Stops iteration if condition evaluates to `True`
+        max_depth: maximum depth of iteration, based on `depth` attribute
 
     Returns:
-        (Iterable[BaseNode])
+        Iterable of nodes
     """
 
     def _levelorder_iter(trees: List[BaseNodeT]) -> Iterable[BaseNodeT]:
@@ -319,25 +312,23 @@ def levelordergroup_iter(
         [['a'], ['b', 'c'], ['d', 'e', 'f']]
 
     Args:
-        tree (BaseNode): input tree
-        filter_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Return node if condition evaluates to `True`
-        stop_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Stops iteration if condition evaluates to `True`
-        max_depth (int): maximum depth of iteration, based on `depth` attribute, defaults to None
+        tree: input tree
+        filter_condition: function that takes in node as argument. Return node if condition evaluates to `True`
+        stop_condition: function that takes in node as argument. Stops iteration if condition evaluates to `True`
+        max_depth: maximum depth of iteration, based on `depth` attribute
 
     Returns:
-        (Iterable[Iterable[BaseNode]])
+        List of iterable of nodes
     """
 
     def _levelordergroup_iter(trees: List[BaseNodeT]) -> Iterable[Iterable[BaseNodeT]]:
         """Iterate through all children of a tree.
 
         Args:
-            trees (List[BaseNode]): trees to get children for next level
+            trees: trees to get children for next level
 
         Returns:
-            (Iterable[Iterable[BaseNode]])
+            List of iterable of nodes
         """
         current_tree = []
         next_level = []
@@ -393,15 +384,13 @@ def zigzag_iter(
         ['a', 'c', 'b', 'd', 'e', 'f']
 
     Args:
-        tree (BaseNode): input tree
-        filter_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Return node if condition evaluates to `True`
-        stop_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Stops iteration if condition evaluates to `True`
-        max_depth (int): maximum depth of iteration, based on `depth` attribute, defaults to None
+        tree: input tree
+        filter_condition: function that takes in node as argument. Return node if condition evaluates to `True`
+        stop_condition: function that takes in node as argument. Stops iteration if condition evaluates to `True`
+        max_depth: maximum depth of iteration, based on `depth` attribute
 
     Returns:
-        (Iterable[BaseNode])
+        Iterable of nodes
     """
 
     def _zigzag_iter(
@@ -475,15 +464,13 @@ def zigzaggroup_iter(
         [['a'], ['c', 'b'], ['d', 'e', 'f']]
 
     Args:
-        tree (BaseNode): input tree
-        filter_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Return node if condition evaluates to `True`
-        stop_condition (Optional[Callable[[BaseNode], bool]]): function that takes in node as argument, optional
-            Stops iteration if condition evaluates to `True`
-        max_depth (int): maximum depth of iteration, based on `depth` attribute, defaults to None
+        tree: input tree
+        filter_condition: function that takes in node as argument. Return node if condition evaluates to `True`
+        stop_condition: function that takes in node as argument. Stops iteration if condition evaluates to `True`
+        max_depth: maximum depth of iteration, based on `depth` attribute
 
     Returns:
-        (Iterable[Iterable[BaseNode]])
+        List of iterable of nodes
     """
 
     def _zigzaggroup_iter(
@@ -492,11 +479,11 @@ def zigzaggroup_iter(
         """Iterate through all children of a tree.
 
         Args:
-            trees (List[BaseNode]): trees to get children for next level
-            reverse_indicator (bool): indicator whether it is in reverse order
+            trees: trees to get children for next level
+            reverse_indicator: indicator whether it is in reverse order
 
         Returns:
-            (Iterable[Iterable[BaseNode]])
+            List of iterable of nodes
         """
         current_tree = []
         next_level = []
@@ -520,9 +507,8 @@ def zigzaggroup_iter(
 
 
 def dag_iterator(dag: DAGNodeT) -> Iterable[Tuple[DAGNodeT, DAGNodeT]]:
-    """Iterate through all nodes of a Directed Acyclic Graph (DAG).
-    Note that node names must be unique.
-    Note that DAG must at least have two nodes to be shown on graph.
+    """Iterate through all nodes of a Directed Acyclic Graph (DAG). Note that node names
+    must be unique. Note that DAG must at least have two nodes to be shown on graph.
 
     1. Visit the current node.
     2. Recursively traverse the current node's parents.
@@ -539,10 +525,10 @@ def dag_iterator(dag: DAGNodeT) -> Iterable[Tuple[DAGNodeT, DAGNodeT]]:
         [('a', 'c'), ('a', 'd'), ('b', 'c'), ('c', 'd'), ('d', 'e')]
 
     Args:
-        dag (DAGNode): input dag
+        dag: input dag
 
     Returns:
-        (Iterable[Tuple[DAGNode, DAGNode]])
+        Iterable of parent-child pair
     """
     visited_nodes = set()
 
@@ -550,10 +536,10 @@ def dag_iterator(dag: DAGNodeT) -> Iterable[Tuple[DAGNodeT, DAGNodeT]]:
         """Iterate through all children of a DAG.
 
         Args:
-            node (DAGNode): current node
+            node: current node
 
         Returns:
-            (Iterable[Tuple[DAGNode, DAGNode]])
+            Iterable of parent-child pair
         """
         node_name = node.node_name
         visited_nodes.add(node_name)

--- a/bigtree/utils/plot.py
+++ b/bigtree/utils/plot.py
@@ -72,13 +72,13 @@ def reingold_tilford(
     - [2] Reingold, E., Tilford, J. (1981). Tidier Drawings of Trees. IEEE Transactions on Software Engineering. https://reingold.co/tidier-drawings.pdf
 
     Args:
-        tree_node (BaseNode): tree to compute (x, y) coordinate
-        sibling_separation (float): minimum distance between adjacent siblings of the tree
-        subtree_separation (float): minimum distance between adjacent subtrees of the tree
-        level_separation (float): fixed distance between adjacent levels of the tree
-        x_offset (float): graph offset of x-coordinates
-        y_offset (float): graph offset of y-coordinates
-        reverse (bool): graph begins bottom to top by default, set to True for top to bottom y coordinates
+        tree_node: tree to compute (x, y) coordinate
+        sibling_separation: minimum distance between adjacent siblings of the tree
+        subtree_separation: minimum distance between adjacent subtrees of the tree
+        level_separation: fixed distance between adjacent levels of the tree
+        x_offset: graph offset of x-coordinates
+        y_offset: graph offset of y-coordinates
+        reverse: graph begins bottom to top by default, set to True for top to bottom y coordinates
     """
     _first_pass(tree_node, sibling_separation, subtree_separation)
     x_adjustment = _second_pass(
@@ -104,8 +104,8 @@ def plot_tree(
         <Figure size 1280x960 with 1 Axes>
 
     Args:
-        tree_node (BaseNode): tree to plot
-        ax (plt.Axes): axes to add Figure to
+        tree_node: tree to plot
+        ax: axes to add Figure to
     """
     if ax:
         fig = ax.get_figure()
@@ -168,9 +168,9 @@ def _first_pass(
       `shift` value to keep nodes centralized at the level.
 
     Args:
-        tree_node (BaseNode): tree to compute (x, y) coordinate
-        sibling_separation (float): minimum distance between adjacent siblings of the tree
-        subtree_separation (float): minimum distance between adjacent subtrees of the tree
+        tree_node: tree to compute (x, y) coordinate
+        sibling_separation: minimum distance between adjacent siblings of the tree
+        subtree_separation: minimum distance between adjacent subtrees of the tree
     """
     # Post-order iteration (LRN)
     for child in tree_node.children:
@@ -235,13 +235,13 @@ def _first_pass(
 
 
 def _get_midpoint_of_children(tree_node: basenode.BaseNode) -> float:
-    """Get midpoint of children of a node
+    """Get midpoint of children of a node.
 
     Args:
-        tree_node (BaseNode): tree node to obtain midpoint of their child/children
+        tree_node: tree node to obtain midpoint of their child/children
 
     Returns:
-        (float)
+        Midpoint of children
     """
     if tree_node.children:
         first_child_x: float = tree_node.children[0].get_attr("x") + tree_node.children[
@@ -265,21 +265,21 @@ def _get_subtree_shift(
     cum_shift: float = 0,
     initial_run: bool = True,
 ) -> float:
-    """Get shift amount to shift the right subtree towards the right such that it does not overlap with the left subtree
+    """Get shift amount to shift the right subtree towards the right such that it does not overlap with the left subtree.
 
     Args:
-        left_subtree (BaseNode): left subtree, with right contour to be traversed
+        left_subtree: left subtree, with right contour to be traversed
         right_subtree (BaseNode): right subtree, with left contour to be traversed
-        left_idx (int): index of left subtree, to compute overlap for relative shift (constant across iteration)
-        right_idx (int): index of right subtree, to compute overlap for relative shift (constant across iteration)
-        subtree_separation (float): minimum distance between adjacent subtrees of the tree (constant across iteration)
-        left_cum_shift (float): cumulative `mod + shift` for left subtree from the ancestors, defaults to 0
-        right_cum_shift (float): cumulative `mod + shift` for right subtree from the ancestors, defaults to 0
-        cum_shift (float): cumulative shift amount for right subtree, defaults to 0
-        initial_run (bool): indicates whether left_subtree and right_subtree are the main subtrees, defaults to True
+        left_idx: index of left subtree, to compute overlap for relative shift (constant across iteration)
+        right_idx: index of right subtree, to compute overlap for relative shift (constant across iteration)
+        subtree_separation: minimum distance between adjacent subtrees of the tree (constant across iteration)
+        left_cum_shift: cumulative `mod + shift` for left subtree from the ancestors
+        right_cum_shift: cumulative `mod + shift` for right subtree from the ancestors
+        cum_shift: cumulative shift amount for right subtree
+        initial_run: indicates whether left_subtree and right_subtree are the main subtrees
 
     Returns:
-        (float)
+        Amount to shift subtree
     """
     new_shift = 0.0
 
@@ -357,17 +357,17 @@ def _second_pass(
       - :math:`y = (depth - node.depth) * distance + y'`
 
     Args:
-        tree_node (BaseNode): tree to compute (x, y) coordinate
-        level_separation (float): fixed distance between adjacent levels of the tree (constant across iteration)
-        x_offset (float): graph offset of x-coordinates (constant across iteration)
-        y_offset (float): graph offset of y-coordinates (constant across iteration)
-        reverse (bool): graph begins bottom to top by default, set to True for top to bottom y coordinates
-        cum_mod (Optional[float]): cumulative `mod + shift` for tree/subtree from the ancestors
-        max_depth (Optional[int]): maximum depth of tree (constant across iteration)
-        x_adjustment (Optional[float]): amount of x-adjustment for third pass, in case any x-coordinates goes below 0
+        tree_node: tree to compute (x, y) coordinate
+        level_separation: fixed distance between adjacent levels of the tree (constant across iteration)
+        x_offset: graph offset of x-coordinates (constant across iteration)
+        y_offset: graph offset of y-coordinates (constant across iteration)
+        reverse: graph begins bottom to top by default, set to True for top to bottom y coordinates
+        cum_mod: cumulative `mod + shift` for tree/subtree from the ancestors
+        max_depth: maximum depth of tree (constant across iteration)
+        x_adjustment: amount of x-adjustment for third pass, in case any x-coordinates goes below 0
 
     Returns
-        (float)
+        Amount to shift the node by
     """
     if not max_depth:
         max_depth = tree_node.max_depth
@@ -406,8 +406,8 @@ def _third_pass(tree_node: basenode.BaseNode, x_adjustment: float) -> None:
     Modifies tree in-place.
 
     Args:
-        tree_node (BaseNode): tree to compute (x, y) coordinate
-        x_adjustment (float): amount of adjustment for x-coordinates (constant across iteration)
+        tree_node: tree to compute (x, y) coordinate
+        x_adjustment: amount of adjustment for x-coordinates (constant across iteration)
     """
     if x_adjustment:
         tree_node.set_attrs({"x": tree_node.get_attr("x") + x_adjustment})

--- a/bigtree/workflows/app_calendar.py
+++ b/bigtree/workflows/app_calendar.py
@@ -67,12 +67,12 @@ class Calendar:
         date_format: str = "%Y-%m-%d %H:%M",
         **kwargs: Any,
     ) -> None:
-        """Add event to calendar
+        """Add event to calendar.
 
         Args:
-            event_name (str): event name to be added
-            event_datetime (Union[str, dt.datetime]): event date and time
-            date_format (str): specify datetime format if event_datetime is str
+            event_name: event name to be added
+            event_datetime: event date and time
+            date_format: specify datetime format if event_datetime is str
         """
         if isinstance(event_datetime, str):
             event_datetime = dt.datetime.strptime(event_datetime, date_format)
@@ -99,11 +99,11 @@ class Calendar:
     def delete_event(
         self, event_name: str, event_date: Optional[dt.date] = None
     ) -> None:
-        """Delete event from calendar
+        """Delete event from calendar.
 
         Args:
-            event_name (str): event name to be deleted
-            event_date (dt.date): event date to be deleted
+            event_name: event name to be deleted
+            event_date: event date to be deleted
         """
         if event_date:
             year, month, day = (
@@ -124,10 +124,10 @@ class Calendar:
                 self._delete_event(event)
 
     def find_event(self, event_name: str) -> None:
-        """Find event by name, prints result to console
+        """Find event by name, prints result to console.
 
         Args:
-            event_name (str): event name
+            event_name: event name
         """
         if not self.__sorted:
             self._sort()
@@ -137,7 +137,7 @@ class Calendar:
             self._show(event)
 
     def show(self) -> None:
-        """Show calendar, prints result to console"""
+        """Show calendar, prints result to console."""
         if not len(self.calendar.children):
             raise Exception("Calendar is empty!")
         if not self.__sorted:
@@ -148,10 +148,10 @@ class Calendar:
 
     def to_dataframe(self) -> pd.DataFrame:
         """
-        Export calendar to DataFrame
+        Export calendar to DataFrame.
 
         Returns:
-            (pd.DataFrame)
+            pandas DataFrame of calendar
         """
         if not len(self.calendar.children):
             raise Exception("Calendar is empty!")
@@ -161,10 +161,10 @@ class Calendar:
         return data[compulsory_cols + other_cols]
 
     def _delete_event(self, event: node.Node) -> None:
-        """Private method to delete event, delete parent node as well
+        """Private method to delete event, delete parent node as well.
 
         Args:
-            event (Node): event to be deleted
+            event: event to be deleted
         """
         if len(event.parent.children) == 1:
             if event.parent.parent:
@@ -184,11 +184,11 @@ class Calendar:
 
     @staticmethod
     def _show(event: node.Node) -> None:
-        """Private method to show event, handles the formatting of event
-        Prints result to console
+        """Private method to show event, handles the formatting of event.
+        Prints result to console.
 
         Args:
-            event (Node): event
+            event: event
         """
         event_datetime = dt.datetime.combine(
             event.get_attr("date"), event.get_attr("time")

--- a/bigtree/workflows/app_todo.py
+++ b/bigtree/workflows/app_todo.py
@@ -86,23 +86,23 @@ class AppToDo:
         self,
         app_name: str = "",
     ):
-        """Initialize To-Do app
+        """Initialize To-Do app.
 
         Args:
-            app_name (str): name of to-do app, optional
+            app_name: name of to-do app, optional
         """
         self._root = node.Node(app_name)
 
     def add_list(self, list_name: str, **kwargs: Any) -> node.Node:
-        """Add list to app
+        """Add list to app.
 
         If list is present, return list node, else a new list will be created
 
         Args:
-            list_name (str): name of list
+            list_name: name of list
 
         Returns:
-            (Node)
+            List node
         """
         list_node = search.find_child_by_name(self._root, list_name)
         if not list_node:
@@ -111,10 +111,10 @@ class AppToDo:
         return list_node
 
     def prioritize_list(self, list_name: str) -> None:
-        """Prioritize list in app, shift it to be the first list
+        """Prioritize list in app, shift it to be the first list.
 
         Args:
-            list_name (str): name of list
+            list_name: name of list
         """
         list_node = search.find_child_by_name(self._root, list_name)
         if not list_node:
@@ -127,11 +127,11 @@ class AppToDo:
     def add_item(
         self, item_name: Union[str, List[str]], list_name: str = "", **kwargs: Any
     ) -> None:
-        """Add items to list
+        """Add items to list.
 
         Args:
-            item_name (str/List[str]): items to be added
-            list_name (str): list to add items to, optional
+            item_name: items to be added
+            list_name: list to add items to, optional
         """
         if not isinstance(item_name, str) and not isinstance(item_name, list):
             raise TypeError("Invalid data type for item")
@@ -152,11 +152,11 @@ class AppToDo:
     def remove_item(
         self, item_name: Union[str, List[str]], list_name: str = ""
     ) -> None:
-        """Remove items from list
+        """Remove items from list.
 
         Args:
-            item_name (str/List[str]): items to be added
-            list_name (str): list to add items to, optional
+            item_name: items to be added
+            list_name: list to add items to, optional
         """
         if not isinstance(item_name, str) and not isinstance(item_name, list):
             raise TypeError("Invalid data type for item")
@@ -204,10 +204,10 @@ class AppToDo:
                 logging.info(f"Removed list {list_node.node_name}")
 
     def prioritize_item(self, item_name: str) -> None:
-        """Prioritize item in list, shift it to be the first item in list
+        """Prioritize item in list, shift it to be the first item in list.
 
         Args:
-            item_name (str): name of item
+            item_name: name of item
         """
         item_node = search.find_name(self._root, item_name)
         if not item_node:
@@ -222,18 +222,18 @@ class AppToDo:
         current_parent.children = current_children  # type: ignore
 
     def show(self, **kwargs: Any) -> None:
-        """Print tree to console"""
+        """Print tree to console."""
         export.print_tree(self._root, all_attrs=True, **kwargs)
 
     @staticmethod
     def load(json_path: str) -> AppToDo:
-        """Load To-Do app from json
+        """Load To-Do app from json.
 
         Args:
-            json_path (str): json load path
+            json_path: json load path
 
         Returns:
-            (Self)
+            AppToDo loaded from path
         """
         if not json_path.endswith(".json"):
             raise ValueError("Path should end with .json")
@@ -247,10 +247,10 @@ class AppToDo:
         return _app
 
     def save(self, json_path: str) -> None:
-        """Save To-Do app as json
+        """Save To-Do app as json.
 
         Args:
-            json_path (str): json save path
+            json_path: json save path
         """
         if not json_path.endswith(".json"):
             raise ValueError("Path should end with .json")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -139,7 +139,7 @@ class Constants:
         "Expect open and close brackets in `attr_bracket`, received {attr_bracket}"
     )
     ERROR_NODE_EXPORT_PRINT_STYLE_SELECT = (
-        "Please specify the style of stem, branch, and final stem in `style`"
+        "Please specify the style of 3 icons in `style`"
     )
     ERROR_NODE_EXPORT_HPRINT_STYLE_SELECT = (
         "Please specify the style of 7 icons in `style`"


### PR DESCRIPTION
## Description
- Deduplicate docstring by removing default and type hint
- Fix coverage by skipping test for NotImplementedError
- Minor improvements in export yield tree codes to make code shorter

## Testing
<!-- Describe the tests added (tests for new feature, tests for bugfix) -->

## Additional notes
<!-- Any information that might be useful for review -->

## Checklist
I have read through the [contributing guidelines](https://bigtree.readthedocs.io/en/stable/home/contributing/) and ensured that
- [x] I have added a descriptive title for this pull request.
- [x] I have followed the convention and standards, and my code is checked for style and correctness.
- [x] I have added test cases, and unit tests pass with 100% code coverage.
- [x] I have updated the documentation and code docstrings.

## Checklist (for reviewer)
- [x] I have added label (breaking / enhancement / bug / documentation) to this pull request, if applicable.
- [x] I will ensure this change is captured in the *CHANGELOG.md* file.
