### PR TITLE
Query tree using Tree Definition Language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Tree Query: Query tree using SQL-like syntax.
 
 ## [0.28.0] - 2025-04-19
 ### Added:

--- a/bigtree/__init__.py
+++ b/bigtree/__init__.py
@@ -63,6 +63,7 @@ from bigtree.tree.modify import (
     shift_nodes,
 )
 from bigtree.tree.parsing import get_common_ancestors, get_path
+from bigtree.tree.query import query_tree
 from bigtree.tree.search import (
     find,
     find_attr,

--- a/bigtree/node/basenode.py
+++ b/bigtree/node/basenode.py
@@ -120,6 +120,7 @@ class BaseNode:
     7. ``copy()``: Deep copy self
     8. ``sort()``: Sort child nodes
     9. ``plot()``: Plot tree in line form
+    10. ``query(query: str)``: Filter tree using Tree Query Language
 
     ----
 
@@ -732,6 +733,20 @@ class BaseNode:
         if self.get_attr("x") is None or self.get_attr("y") is None:
             reingold_tilford(self)
         return plot_tree(self, *args, **kwargs)
+
+    def query(self, query: str, debug: bool = False) -> List[T]:
+        """Query tree using Tree Definition Language.
+
+        Args:
+            query: query
+            debug: if True, will print out the parsed query
+
+        Returns:
+            List of nodes that fulfil the condition of query
+        """
+        from bigtree.tree.query import query_tree
+
+        return query_tree(self, query, debug)
 
     def __copy__(self: T) -> T:
         """Shallow copy self.

--- a/bigtree/node/basenode.py
+++ b/bigtree/node/basenode.py
@@ -721,7 +721,6 @@ class BaseNode:
         """Plot tree in line form. Accepts args and kwargs for matplotlib.pyplot.plot() function.
 
         Examples:
-            >>> import matplotlib.pyplot as plt
             >>> from bigtree import list_to_tree
             >>> path_list = ["a/b/d", "a/b/e/g", "a/b/e/h", "a/c/f"]
             >>> root = list_to_tree(path_list)
@@ -736,6 +735,13 @@ class BaseNode:
 
     def query(self, query: str, debug: bool = False) -> List[T]:
         """Query tree using Tree Definition Language.
+
+        Examples:
+            >>> from bigtree import list_to_tree
+            >>> path_list = ["a/b/d", "a/b/e/g", "a/b/e/h", "a/c/f"]
+            >>> root = list_to_tree(path_list)
+            >>> root.query("depth == 2")
+            [Node(/a/b, ), Node(/a/c, )]
 
         Args:
             query: query

--- a/bigtree/tree/export/vis.py
+++ b/bigtree/tree/export/vis.py
@@ -21,7 +21,7 @@ __all__ = [
 T = TypeVar("T", bound=node.Node)
 
 
-@exceptions.optional_dependencies_pyvis
+@exceptions.optional_dependencies_vis
 def tree_to_vis(
     tree: T,
     alias: str = "node_name",

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -175,14 +175,14 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
         %import common.WS
         %ignore WS
     """
-
-    parser = Lark(
-        query_grammar, start="start", parser="lalr", transformer=QueryTransformer()
-    )
+    if debug:
+        parser = Lark(query_grammar, start="start", parser="lalr", debug=True)
+    else:
+        parser = Lark(
+            query_grammar, start="start", parser="lalr", transformer=QueryTransformer()
+        )
     tree = parser.parse(query)
     if debug:
-        parser = Lark(query_grammar, start="start", parser="lalr")
-        tree = parser.parse(query)
         print(tree)
         print(tree.pretty())
 

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -176,9 +176,13 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
         %ignore WS
     """
 
-    parser = Lark(query_grammar, start="start", parser="lalr")
+    parser = Lark(
+        query_grammar, start="start", parser="lalr", transformer=QueryTransformer()
+    )
     tree = parser.parse(query)
     if debug:
+        parser = Lark(query_grammar, start="start", parser="lalr")
+        tree = parser.parse(query)
         print(tree)
         print(tree.pretty())
 

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -33,12 +33,12 @@ class QueryTransformer(Transformer):  # type: ignore
     }
 
     @staticmethod
-    def and_clause(args: List[Callable[[T], bool]]) -> Callable[[T], bool]:
-        return lambda node: all(cond(node) for cond in args)
-
-    @staticmethod
     def or_clause(args: List[Callable[[T], bool]]) -> Callable[[T], bool]:
         return lambda node: any(cond(node) for cond in args)
+
+    @staticmethod
+    def and_clause(args: List[Callable[[T], bool]]) -> Callable[[T], bool]:
+        return lambda node: all(cond(node) for cond in args)
 
     def comparison(self, args: List[Token]) -> Callable[[T], bool]:
         attr, op, value = args
@@ -166,10 +166,10 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
 
         ?attr: /[a-zA-Z_][a-zA-Z0-9_]*/
         object_attr: attr ("." attr)*
+        list: "[" [value ("," value)*] "]"
         value: string | number
         string: ESCAPED_STRING
         number: SIGNED_NUMBER
-        list: "[" [value ("," value)*] "]"
 
         OP: "==" | "!=" | ">" | "<" | ">=" | "<="
         OP_CONTAINS: "contains"

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -88,6 +88,10 @@ class QueryTransformer(Transformer):  # type: ignore
 def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
     """Query tree using Tree Definition Language.
 
+    - Supports clauses: AND, OR
+    - Supports operation: ==, !=, >, <, >=, <=, contains, in
+    - Note that string match in query must be in double quotes
+
     Examples:
         >>> from bigtree import Node, dict_to_tree, query_tree
         >>> paths = {

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -74,8 +74,16 @@ class QueryTransformer(Transformer):  # type: ignore
     @staticmethod
     def value(args: List[Token]) -> Any:
         val = args[0]
-        if val.type == "ESCAPED_STRING":
-            return val[1:-1]
+        return val
+
+    @staticmethod
+    def string(args: List[Token]) -> Any:
+        val = args[0]
+        return val[1:-1]
+
+    @staticmethod
+    def number(args: List[Token]) -> Any:
+        val = args[0]
         try:
             return int(val.value)
         except ValueError:
@@ -153,14 +161,16 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
                | comparison
                | unary
 
-        ?comparison: object_attr OP value         -> comparison
-                | object_attr OP_CONTAINS value   -> comparison
-                | object_attr OP_IN list          -> comparison
-        ?unary: object_attr                       -> unary
+        ?comparison: object_attr OP value          -> comparison
+                | object_attr OP_CONTAINS string   -> comparison
+                | object_attr OP_IN list           -> comparison
+        ?unary: object_attr                        -> unary
 
         ?attr: /[a-zA-Z_][a-zA-Z0-9_]*/
         object_attr: attr ("." attr)*
-        value: ESCAPED_STRING | SIGNED_NUMBER
+        value: string | number
+        string: ESCAPED_STRING
+        number: SIGNED_NUMBER
         list: "[" [value ("," value)*] "]"
 
         OP: "==" | "!=" | ">" | "<" | ">=" | "<="

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -58,10 +58,6 @@ class QueryTransformer(Transformer):  # type: ignore
         return lambda node: not attr(node)
 
     @staticmethod
-    def attr(args: List[Token]) -> Any:
-        return args[0]
-
-    @staticmethod
     def object_attr(args: List[Token]) -> Callable[[T], Any]:
         # e.g., ['parent', 'name'] => lambda node: node.parent.name
         def accessor(node: T) -> Any:
@@ -77,10 +73,6 @@ class QueryTransformer(Transformer):  # type: ignore
     @staticmethod
     def list(args: List[Token]) -> Any:
         return list(args)
-
-    @staticmethod
-    def value(args: List[Token]) -> Any:
-        return args[0]
 
     @staticmethod
     def string(args: List[Token]) -> Any:
@@ -167,16 +159,16 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
                | unary
                | not_comparison
 
-        comparison: object_attr OP value
+        comparison: object_attr OP _value
                 | object_attr OP_CONTAINS string
                 | object_attr OP_IN list
         unary: object_attr
         not_comparison: "NOT" predicate
 
-        attr: /[a-zA-Z_][a-zA-Z0-9_]*/
-        object_attr: attr ("." attr)*
-        list: "[" [value ("," value)*] "]"
-        value: string | number
+        _attr: /[a-zA-Z_][a-zA-Z0-9_]*/
+        object_attr: _attr ("." _attr)*
+        list: "[" [_value ("," _value)*] "]"
+        _value: string | number
         string: ESCAPED_STRING
         number: SIGNED_NUMBER
 

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -73,13 +73,11 @@ class QueryTransformer(Transformer):  # type: ignore
 
     @staticmethod
     def value(args: List[Token]) -> Any:
-        val = args[0]
-        return val
+        return args[0]
 
     @staticmethod
     def string(args: List[Token]) -> Any:
-        val = args[0]
-        return val[1:-1]
+        return args[0][1:-1]
 
     @staticmethod
     def number(args: List[Token]) -> Any:

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -44,8 +44,6 @@ class QueryTransformer(Transformer):  # type: ignore
         attr, op, value = args
         if not isinstance(attr, Callable):  # type: ignore
             attr = self.object_attr([attr])
-        if op != "in":
-            value = self.value([value])
         op_func = self.OPERATORS[op]
         if op in ("contains", "in"):
             return lambda node: op_func(attr(node) or "", value)
@@ -71,7 +69,7 @@ class QueryTransformer(Transformer):  # type: ignore
         return accessor
 
     def list(self, args: List[Token]) -> Any:
-        return [self.value([arg]) for arg in args]
+        return list(args)
 
     @staticmethod
     def value(args: List[Token]) -> Any:
@@ -161,10 +159,9 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
         ?unary: object_attr                       -> unary
 
         ?attr: /[a-zA-Z_][a-zA-Z0-9_]*/
-        ?object_attr: attr ("." attr)*
-        ?value: ESCAPED_STRING | SIGNED_NUMBER
-        ?item: ESCAPED_STRING
-        ?list: "[" [item ("," item)*] "]"
+        object_attr: attr ("." attr)*
+        value: ESCAPED_STRING | SIGNED_NUMBER
+        list: "[" [value ("," value)*] "]"
 
         OP: "==" | "!=" | ">" | "<" | ">=" | "<="
         OP_CONTAINS: "contains"

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -166,10 +166,10 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
                | comparison
                | unary
 
-        ?comparison: object_attr OP value          -> comparison
-                | object_attr OP_CONTAINS string   -> comparison
-                | object_attr OP_IN list           -> comparison
-        ?unary: object_attr                        -> unary
+        comparison: object_attr OP value
+                | object_attr OP_CONTAINS string
+                | object_attr OP_IN list
+        unary: object_attr
 
         attr: /[a-zA-Z_][a-zA-Z0-9_]*/
         object_attr: attr ("." attr)*

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -57,6 +57,12 @@ class QueryTransformer(Transformer):  # type: ignore
             attr = self.object_attr([attr])
         return lambda node: bool(attr(node))
 
+    def not_comparison(self, args: List[Token]) -> Callable[[T], bool]:
+        attr = args[0]
+        if not isinstance(attr, Callable):  # type: ignore
+            attr = self.object_attr([attr])
+        return lambda node: not attr(node)
+
     @staticmethod
     def attr(args: List[Token]) -> Any:
         return args[0]
@@ -99,7 +105,7 @@ class QueryTransformer(Transformer):  # type: ignore
 def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
     """Query tree using Tree Definition Language.
 
-    - Supports clauses: AND, OR
+    - Supports clauses: AND, OR, NOT
     - Supports operation: ==, !=, >, <, >=, <=, contains, in
     - Note that string match in query must be in double quotes
 
@@ -165,11 +171,13 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
         ?predicate: "(" predicate ")"
                | comparison
                | unary
+               | not_comparison
 
         comparison: object_attr OP value
                 | object_attr OP_CONTAINS string
                 | object_attr OP_IN list
         unary: object_attr
+        not_comparison: "NOT" predicate
 
         attr: /[a-zA-Z_][a-zA-Z0-9_]*/
         object_attr: attr ("." attr)*

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -143,13 +143,12 @@ def query_tree(tree_node: T, query: str, debug: bool = False) -> List[T]:
     query_grammar = """
         ?start: expr
 
-        ?term: term "AND" factor  -> and_expr
-             | factor
+        ?and_clause: predicate ("AND" predicate)*   -> and_expr
 
-        ?expr: expr "OR" term     -> or_expr
-             | term
+        ?expr: expr "OR" and_clause     -> or_expr
+             | and_clause
 
-        ?factor: "(" expr ")"
+        ?predicate: "(" predicate ")"
                | condition
                | unary_condition
 

--- a/bigtree/tree/query.py
+++ b/bigtree/tree/query.py
@@ -44,8 +44,6 @@ class QueryTransformer(Transformer):  # type: ignore
 
     def comparison(self, args: List[Token]) -> Callable[[T], bool]:
         attr, op, value = args
-        if not isinstance(attr, Callable):  # type: ignore
-            attr = self.object_attr([attr])
         op_func = self.OPERATORS[op]
         if op in ("contains", "in"):
             return lambda node: op_func(attr(node) or "", value)
@@ -53,14 +51,10 @@ class QueryTransformer(Transformer):  # type: ignore
 
     def unary(self, args: List[Token]) -> Callable[[T], bool]:
         attr = args[0]
-        if not isinstance(attr, Callable):  # type: ignore
-            attr = self.object_attr([attr])
         return lambda node: bool(attr(node))
 
     def not_comparison(self, args: List[Token]) -> Callable[[T], bool]:
         attr = args[0]
-        if not isinstance(attr, Callable):  # type: ignore
-            attr = self.object_attr([attr])
         return lambda node: not attr(node)
 
     @staticmethod

--- a/bigtree/utils/exceptions.py
+++ b/bigtree/utils/exceptions.py
@@ -69,6 +69,62 @@ def deprecated(
     return decorator
 
 
+def optional_dependencies_image(
+    package_name: str = "",
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        """
+        This is a decorator which can be used to import optional image dependency. It will raise an ImportError if the
+        module is not found.
+        """
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            if not package_name or package_name == "pydot":
+                try:
+                    import pydot  # noqa: F401
+                except ImportError:  # pragma: no cover
+                    raise ImportError(
+                        "pydot not available. Please perform a\n\n"
+                        "pip install 'bigtree[image]'\n\nto install required dependencies"
+                    ) from None
+            if not package_name or package_name == "Pillow":
+                try:
+                    from PIL import Image, ImageDraw, ImageFont  # noqa: F401
+                except ImportError:  # pragma: no cover
+                    raise ImportError(
+                        "Pillow not available. Please perform a\n\n"
+                        "pip install 'bigtree[image]'\n\nto install required dependencies"
+                    ) from None
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def optional_dependencies_matplotlib(
+    func: Callable[..., T],
+) -> Callable[..., T]:  # pragma: no cover
+    """
+    This is a decorator which can be used to import optional matplotlib dependency. It will raise an ImportError if the
+    module is not found.
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        try:
+            import matplotlib.pyplot as plt  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "matplotlib not available. Please perform a\n\n"
+                "pip install 'bigtree[matplotlib]'\n\nto install required dependencies"
+            ) from None
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def optional_dependencies_pandas(
     func: Callable[..., T],
 ) -> Callable[..., T]:  # pragma: no cover
@@ -113,63 +169,29 @@ def optional_dependencies_polars(
     return wrapper
 
 
-def optional_dependencies_matplotlib(
+def optional_dependencies_query(
     func: Callable[..., T],
 ) -> Callable[..., T]:  # pragma: no cover
     """
-    This is a decorator which can be used to import optional matplotlib dependency. It will raise an ImportError if the
+    This is a decorator which can be used to import optional lark dependency. It will raise an ImportError if the
     module is not found.
     """
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> T:
         try:
-            import matplotlib.pyplot as plt  # noqa: F401
+            import lark  # noqa: F401
         except ImportError:
             raise ImportError(
-                "matplotlib not available. Please perform a\n\n"
-                "pip install 'bigtree[matplotlib]'\n\nto install required dependencies"
+                "lark not available. Please perform a\n\n"
+                "pip install 'bigtree[query]'\n\nto install required dependencies"
             ) from None
         return func(*args, **kwargs)
 
     return wrapper
 
 
-def optional_dependencies_image(
-    package_name: str = "",
-) -> Callable[[Callable[..., T]], Callable[..., T]]:
-    def decorator(func: Callable[..., T]) -> Callable[..., T]:
-        """
-        This is a decorator which can be used to import optional image dependency. It will raise an ImportError if the
-        module is not found.
-        """
-
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> T:
-            if not package_name or package_name == "pydot":
-                try:
-                    import pydot  # noqa: F401
-                except ImportError:  # pragma: no cover
-                    raise ImportError(
-                        "pydot not available. Please perform a\n\n"
-                        "pip install 'bigtree[image]'\n\nto install required dependencies"
-                    ) from None
-            if not package_name or package_name == "Pillow":
-                try:
-                    from PIL import Image, ImageDraw, ImageFont  # noqa: F401
-                except ImportError:  # pragma: no cover
-                    raise ImportError(
-                        "Pillow not available. Please perform a\n\n"
-                        "pip install 'bigtree[image]'\n\nto install required dependencies"
-                    ) from None
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-def optional_dependencies_pyvis(
+def optional_dependencies_vis(
     func: Callable[..., T],
 ) -> Callable[..., T]:  # pragma: no cover
     """

--- a/docs/bigtree/tree/query.md
+++ b/docs/bigtree/tree/query.md
@@ -1,0 +1,5 @@
+---
+title: Tree Query
+---
+
+::: bigtree.tree.query

--- a/docs/gettingstarted/demo/tree.md
+++ b/docs/gettingstarted/demo/tree.md
@@ -596,6 +596,7 @@ Below is the table of operations available to `BaseNode` and `Node` classes.
 | Copy tree                                       | `root.copy()`                                              | None                                       |
 | Sort children                                   | `root.sort(key=lambda node: node.node_name, reverse=True)` | None                                       |
 | Plot tree                                       | `root.plot("-ok")`                                         | plt.Figure()                               |
+| Query tree                                      | `root.query('name == "b"')`                                | [Node(/a/b, )]                             |
 
 ## Traverse Tree
 

--- a/docs/home/install.md
+++ b/docs/home/install.md
@@ -35,6 +35,7 @@ Examples of extra packages include:
 - `matplotlib`: for plotting trees
 - `pandas`: for pandas methods
 - `polars`: for polars methods
+- `query` for tree query methods
 - `vis`: for pyvis visualisation
 
 For `image` extra dependency, you may need to install more plugins.

--- a/docs/home/tree.md
+++ b/docs/home/tree.md
@@ -29,7 +29,7 @@ For **Tree** implementation, there are 11 main components.
 - ZigZag Traversal
 - ZigZag-Group Traversal
 
-## [**➰ Parsing Tree**](../bigtree/tree/parsing.md)
+## [**🧭 Parsing Tree**](../bigtree/tree/parsing.md)
 - Get common ancestors between nodes
 - Get path from one node to another node
 
@@ -40,7 +40,7 @@ For **Tree** implementation, there are 11 main components.
 - Copy nodes from one tree to another
 - Copy and replace nodes from one tree to another
 
-## [**➰ Querying Tree**](../bigtree/tree/query.md)
+## [**📌 Querying Tree**](../bigtree/tree/query.md)
 - Filter tree using Tree Query Language
 
 ## [**🔍 Tree Search**](../bigtree/tree/search.md)

--- a/docs/home/tree.md
+++ b/docs/home/tree.md
@@ -4,7 +4,7 @@ title: Tree
 
 # 🌲 Tree
 
-For **Tree** implementation, there are 10 main components.
+For **Tree** implementation, there are 11 main components.
 
 ## [**🌺 Node**](../bigtree/node/node.md)
 - ``BaseNode``, extendable class
@@ -39,6 +39,9 @@ For **Tree** implementation, there are 10 main components.
 - Shift and replace nodes from location to destination
 - Copy nodes from one tree to another
 - Copy and replace nodes from one tree to another
+
+## [**➰ Querying Tree**](../bigtree/tree/query.md)
+- Filter tree using Tree Query Language
 
 ## [**🔍 Tree Search**](../bigtree/tree/search.md)
 - Find multiple nodes based on name, partial path, relative path, attribute value, user-defined condition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - bigtree/tree/modify.md
       - bigtree/tree/parsing.md
       - bigtree/tree/search.md
+      - bigtree/tree/query.md
     - 🔧 Utils:
         - bigtree/utils/iterators.md
         - bigtree/utils/plot.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Source = "https://github.com/kayjan/bigtree"
 
 [project.optional-dependencies]
 all = [
+  "lark",
   "matplotlib",
   "pandas",
   "polars",
@@ -49,12 +50,13 @@ image = [
   "pydot",
   "Pillow",
 ]
-vis = [
-  "pyvis"
-]
 matplotlib = ["matplotlib"]
 pandas = ["pandas"]
 polars = ["polars"]
+query = ["lark"]
+vis = [
+  "pyvis"
+]
 
 [tool.hatch.version]
 path = "bigtree/__init__.py"
@@ -64,6 +66,7 @@ dependencies = [
   "black",
   "coverage",
   "isort",
+  "lark",
   "matplotlib",
   "mypy",
   "pandas",

--- a/tests/node/test_node.py
+++ b/tests/node/test_node.py
@@ -412,6 +412,14 @@ def assert_tree_structure_node_self(self):
         expected_str,
     )
 
+    # Test query()
+    results = self.a.query("age >= 30")
+    expected = ["a", "b", "d", "e", "c", "f"]
+    actual = [n.name for n in results]
+    assert (
+        actual == expected
+    ), f"Wrong query results, expected {expected}, received {actual}"
+
 
 def assert_tree_structure_node_root_sep(root):
     # Test path_name

--- a/tests/node/test_node.py
+++ b/tests/node/test_node.py
@@ -415,7 +415,7 @@ def assert_tree_structure_node_self(self):
     # Test query()
     results = self.a.query("age >= 30")
     expected = ["a", "b", "d", "e", "c", "f"]
-    actual = [n.name for n in results]
+    actual = [_node.node_name for _node in results]
     assert (
         actual == expected
     ), f"Wrong query results, expected {expected}, received {actual}"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -211,6 +211,9 @@ class Constants:
     ERROR_MODIFY_SHIFT_SAME_NODE = "Attempting to shift the same node "
     ERROR_MODIFY_REPLACE_SAME_NODE = "Attempting to replace the same node "
 
+    # tree/query
+    ERROR_QUERY_EMPTY = "Please enter a valid query."
+
     # tree/search
     ERROR_SEARCH_RELATIVE_INVALID_PATH = (
         "Invalid path name. Path goes beyond root node."

--- a/tests/tree/test_query.py
+++ b/tests/tree/test_query.py
@@ -43,6 +43,15 @@ class TestQueryTree:
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
 
+    @staticmethod
+    def test_query_tree_object_attr_not(tree_node):
+        results = query.query_tree(tree_node, "NOT parent.name")
+        expected = ["a"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
     # unary
     @staticmethod
     def test_query_tree_unary(tree_node):
@@ -75,6 +84,15 @@ class TestQueryTree:
     def test_query_tree_unary_or(tree_node):
         results = query.query_tree(tree_node, "is_leaf OR is_root")
         expected = ["a", "d", "g", "h", "f"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_unary_not(tree_node):
+        results = query.query_tree(tree_node, "NOT is_leaf")
+        expected = ["a", "b", "e", "c"]
         actual = [_node.node_name for _node in results]
         assert (
             actual == expected
@@ -156,6 +174,16 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
+    def test_query_tree_op_contains_not(tree_node):
+        tree_node["b"].parameter = "something"
+        results = query.query_tree(tree_node, 'NOT parameter contains "thing"')
+        expected = ["a", "d", "e", "g", "h", "c", "f"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
     def test_query_tree_op_in(tree_node):
         tree_node["b"].parameter = "something"
         tree_node["c"].parameter = "thing"
@@ -171,6 +199,15 @@ class TestQueryTree:
     def test_query_tree_op_in_int(tree_node):
         results = query.query_tree(tree_node, "age in [90, 60]")
         expected = ["a", "c"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_in_not(tree_node):
+        results = query.query_tree(tree_node, "NOT age in [90, 60]")
+        expected = ["b", "d", "e", "g", "h", "f"]
         actual = [_node.node_name for _node in results]
         assert (
             actual == expected

--- a/tests/tree/test_query.py
+++ b/tests/tree/test_query.py
@@ -24,6 +24,7 @@ class TestQueryTree:
             query.query_tree(tree_node, "  ")
         assert str(exc_info.value) == Constants.ERROR_QUERY_EMPTY
 
+    # object_attr
     @staticmethod
     def test_query_tree_object_attr_str(tree_node):
         results = query.query_tree(tree_node, 'parent.name == "b"')
@@ -42,6 +43,7 @@ class TestQueryTree:
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
 
+    # unary
     @staticmethod
     def test_query_tree_unary(tree_node):
         results = query.query_tree(tree_node, "is_leaf")
@@ -78,6 +80,7 @@ class TestQueryTree:
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
 
+    # condition
     @staticmethod
     def test_query_tree_op_equal_int(tree_node):
         results = query.query_tree(tree_node, "age == 65")
@@ -164,6 +167,7 @@ class TestQueryTree:
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
 
+    # and_clause
     @staticmethod
     def test_query_tree_and_clause_multiple(tree_node):
         results = query.query_tree(tree_node, 'age == 40 AND name == "d" AND is_leaf')
@@ -184,6 +188,7 @@ class TestQueryTree:
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
 
+    # or_clause
     @staticmethod
     def test_query_tree_or_clause_multiple(tree_node):
         results = query.query_tree(tree_node, 'age == 38 OR name == "d" OR is_root')

--- a/tests/tree/test_query.py
+++ b/tests/tree/test_query.py
@@ -43,7 +43,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_unary_expr(tree_node):
+    def test_query_tree_unary(tree_node):
         results = query.query_tree(tree_node, "is_leaf")
         expected = ["d", "g", "h", "f"]
         actual = [_node.node_name for _node in results]
@@ -52,7 +52,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_unary_expr_object_attr(tree_node):
+    def test_query_tree_unary_object_attr(tree_node):
         results = query.query_tree(tree_node, "parent.siblings")
         expected = ["d", "e", "g", "h", "f"]
         actual = [_node.node_name for _node in results]
@@ -61,7 +61,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_unary_expr_and(tree_node):
+    def test_query_tree_unary_and(tree_node):
         results = query.query_tree(tree_node, "is_leaf AND siblings")
         expected = ["d", "g", "h"]
         actual = [_node.node_name for _node in results]
@@ -70,7 +70,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_unary_expr_or(tree_node):
+    def test_query_tree_unary_or(tree_node):
         results = query.query_tree(tree_node, "is_leaf OR is_root")
         expected = ["a", "d", "g", "h", "f"]
         actual = [_node.node_name for _node in results]
@@ -92,6 +92,51 @@ class TestQueryTree:
         tree_node["b"].age = 65.5
         results = query.query_tree(tree_node, "age == 65.5")
         expected = ["b"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_not_equal(tree_node):
+        results = query.query_tree(tree_node, "age != 65")
+        expected = ["a", "d", "e", "g", "h", "c", "f"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_more_than(tree_node):
+        results = query.query_tree(tree_node, "age > 60")
+        expected = ["a", "b"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_more_than_equal(tree_node):
+        results = query.query_tree(tree_node, "age >= 60")
+        expected = ["a", "b", "c"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_less_than(tree_node):
+        results = query.query_tree(tree_node, "age < 60")
+        expected = ["d", "e", "g", "h", "f"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_less_than_equal(tree_node):
+        results = query.query_tree(tree_node, "age <= 60")
+        expected = ["d", "e", "g", "h", "c", "f"]
         actual = [_node.node_name for _node in results]
         assert (
             actual == expected
@@ -120,7 +165,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_and_expr_multiple(tree_node):
+    def test_query_tree_and_clause_multiple(tree_node):
         results = query.query_tree(tree_node, 'age == 40 AND name == "d" AND is_leaf')
         expected = ["d"]
         actual = [_node.node_name for _node in results]
@@ -129,7 +174,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_and_expr_multiple_parenthesis(tree_node):
+    def test_query_tree_and_clause_multiple_parenthesis(tree_node):
         results = query.query_tree(
             tree_node, '(age == 40) AND (name == "d") AND is_leaf'
         )
@@ -140,7 +185,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_or_expr_multiple(tree_node):
+    def test_query_tree_or_clause_multiple(tree_node):
         results = query.query_tree(tree_node, 'age == 38 OR name == "d" OR is_root')
         expected = ["a", "d", "f"]
         actual = [_node.node_name for _node in results]
@@ -149,7 +194,7 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
-    def test_query_tree_or_expr_multiple_parenthesis(tree_node):
+    def test_query_tree_or_clause_multiple_parenthesis(tree_node):
         results = query.query_tree(tree_node, '(age == 38) OR (name == "d") OR is_root')
         expected = ["a", "d", "f"]
         actual = [_node.node_name for _node in results]

--- a/tests/tree/test_query.py
+++ b/tests/tree/test_query.py
@@ -167,6 +167,15 @@ class TestQueryTree:
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
 
+    @staticmethod
+    def test_query_tree_op_in_int(tree_node):
+        results = query.query_tree(tree_node, "age in [90, 60]")
+        expected = ["a", "c"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
     # and_clause
     @staticmethod
     def test_query_tree_and_clause_multiple(tree_node):

--- a/tests/tree/test_query.py
+++ b/tests/tree/test_query.py
@@ -9,7 +9,7 @@ class TestQueryTree:
     def test_query_tree(tree_node):
         results = query.query_tree(tree_node, "age >= 30", debug=True)
         expected = ["a", "b", "d", "e", "c", "f"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -28,7 +28,7 @@ class TestQueryTree:
     def test_query_tree_object_attr_str(tree_node):
         results = query.query_tree(tree_node, 'parent.name == "b"')
         expected = ["d", "e"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -37,7 +37,7 @@ class TestQueryTree:
     def test_query_tree_object_attr_int(tree_node):
         results = query.query_tree(tree_node, "parent.age == 65")
         expected = ["d", "e"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -46,7 +46,7 @@ class TestQueryTree:
     def test_query_tree_unary_expr(tree_node):
         results = query.query_tree(tree_node, "is_leaf")
         expected = ["d", "g", "h", "f"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -55,7 +55,7 @@ class TestQueryTree:
     def test_query_tree_unary_expr_object_attr(tree_node):
         results = query.query_tree(tree_node, "parent.siblings")
         expected = ["d", "e", "g", "h", "f"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -64,7 +64,7 @@ class TestQueryTree:
     def test_query_tree_unary_expr_and(tree_node):
         results = query.query_tree(tree_node, "is_leaf AND siblings")
         expected = ["d", "g", "h"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -73,7 +73,7 @@ class TestQueryTree:
     def test_query_tree_unary_expr_or(tree_node):
         results = query.query_tree(tree_node, "is_leaf OR is_root")
         expected = ["a", "d", "g", "h", "f"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -82,7 +82,7 @@ class TestQueryTree:
     def test_query_tree_op_equal_int(tree_node):
         results = query.query_tree(tree_node, "age == 65")
         expected = ["b"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -92,7 +92,7 @@ class TestQueryTree:
         tree_node["b"].age = 65.5
         results = query.query_tree(tree_node, "age == 65.5")
         expected = ["b"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -102,7 +102,7 @@ class TestQueryTree:
         tree_node["b"].parameter = "something"
         results = query.query_tree(tree_node, 'parameter contains "thing"')
         expected = ["b"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -114,7 +114,7 @@ class TestQueryTree:
         tree_node["b"]["d"].parameter = "nothing"
         results = query.query_tree(tree_node, 'parameter in ["thing", "something"]')
         expected = ["b", "c"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -123,7 +123,7 @@ class TestQueryTree:
     def test_query_tree_and_expr_multiple(tree_node):
         results = query.query_tree(tree_node, 'age == 40 AND name == "d" AND is_leaf')
         expected = ["d"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"
@@ -132,7 +132,7 @@ class TestQueryTree:
     def test_query_tree_or_expr_multiple(tree_node):
         results = query.query_tree(tree_node, 'age == 38 OR name == "d" OR is_root')
         expected = ["a", "d", "f"]
-        actual = [n.name for n in results]
+        actual = [_node.node_name for _node in results]
         assert (
             actual == expected
         ), f"Wrong query results, expected {expected}, received {actual}"

--- a/tests/tree/test_query.py
+++ b/tests/tree/test_query.py
@@ -129,8 +129,28 @@ class TestQueryTree:
         ), f"Wrong query results, expected {expected}, received {actual}"
 
     @staticmethod
+    def test_query_tree_and_expr_multiple_parenthesis(tree_node):
+        results = query.query_tree(
+            tree_node, '(age == 40) AND (name == "d") AND is_leaf'
+        )
+        expected = ["d"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
     def test_query_tree_or_expr_multiple(tree_node):
         results = query.query_tree(tree_node, 'age == 38 OR name == "d" OR is_root')
+        expected = ["a", "d", "f"]
+        actual = [_node.node_name for _node in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_or_expr_multiple_parenthesis(tree_node):
+        results = query.query_tree(tree_node, '(age == 38) OR (name == "d") OR is_root')
         expected = ["a", "d", "f"]
         actual = [_node.node_name for _node in results]
         assert (

--- a/tests/tree/test_query.py
+++ b/tests/tree/test_query.py
@@ -1,0 +1,138 @@
+import pytest
+
+from bigtree.tree import query
+from tests.test_constants import Constants
+
+
+class TestQueryTree:
+    @staticmethod
+    def test_query_tree(tree_node):
+        results = query.query_tree(tree_node, "age >= 30", debug=True)
+        expected = ["a", "b", "d", "e", "c", "f"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_empty_string(tree_node):
+        with pytest.raises(ValueError) as exc_info:
+            query.query_tree(tree_node, "")
+        assert str(exc_info.value) == Constants.ERROR_QUERY_EMPTY
+
+        with pytest.raises(ValueError) as exc_info:
+            query.query_tree(tree_node, "  ")
+        assert str(exc_info.value) == Constants.ERROR_QUERY_EMPTY
+
+    @staticmethod
+    def test_query_tree_object_attr_str(tree_node):
+        results = query.query_tree(tree_node, 'parent.name == "b"')
+        expected = ["d", "e"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_object_attr_int(tree_node):
+        results = query.query_tree(tree_node, "parent.age == 65")
+        expected = ["d", "e"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_unary_expr(tree_node):
+        results = query.query_tree(tree_node, "is_leaf")
+        expected = ["d", "g", "h", "f"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_unary_expr_object_attr(tree_node):
+        results = query.query_tree(tree_node, "parent.siblings")
+        expected = ["d", "e", "g", "h", "f"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_unary_expr_and(tree_node):
+        results = query.query_tree(tree_node, "is_leaf AND siblings")
+        expected = ["d", "g", "h"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_unary_expr_or(tree_node):
+        results = query.query_tree(tree_node, "is_leaf OR is_root")
+        expected = ["a", "d", "g", "h", "f"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_equal_int(tree_node):
+        results = query.query_tree(tree_node, "age == 65")
+        expected = ["b"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_equal_float(tree_node):
+        tree_node["b"].age = 65.5
+        results = query.query_tree(tree_node, "age == 65.5")
+        expected = ["b"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_contains(tree_node):
+        tree_node["b"].parameter = "something"
+        results = query.query_tree(tree_node, 'parameter contains "thing"')
+        expected = ["b"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_op_in(tree_node):
+        tree_node["b"].parameter = "something"
+        tree_node["c"].parameter = "thing"
+        tree_node["b"]["d"].parameter = "nothing"
+        results = query.query_tree(tree_node, 'parameter in ["thing", "something"]')
+        expected = ["b", "c"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_and_expr_multiple(tree_node):
+        results = query.query_tree(tree_node, 'age == 40 AND name == "d" AND is_leaf')
+        expected = ["d"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"
+
+    @staticmethod
+    def test_query_tree_or_expr_multiple(tree_node):
+        results = query.query_tree(tree_node, 'age == 38 OR name == "d" OR is_root')
+        expected = ["a", "d", "f"]
+        actual = [n.name for n in results]
+        assert (
+            actual == expected
+        ), f"Wrong query results, expected {expected}, received {actual}"


### PR DESCRIPTION
## Description
Able to query tree using SQL-like syntax, relying on (optional) package Lark

## Testing
Added tests to test
- and/or syntax
- different conditions for comparison (contains/in/math operators)
- different attribute (simple/nested)

## Additional notes
<!-- Any information that might be useful for review -->

## Checklist
I have read through the [contributing guidelines](https://bigtree.readthedocs.io/en/stable/home/contributing/) and ensured that
- [x] I have added a descriptive title for this pull request.
- [x] I have followed the convention and standards, and my code is checked for style and correctness.
- [x] I have added test cases, and unit tests pass with 100% code coverage.
- [x] I have updated the documentation and code docstrings.

## Checklist (for reviewer)
- [x] I have added label (breaking / enhancement / bug / documentation) to this pull request, if applicable.
- [x] I will ensure this change is captured in the *CHANGELOG.md* file.
